### PR TITLE
Small Makefile fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ USER_ID?=$$(id -u)
 TARGET_TAG=latest
 
 build:
-	make _build TARGET_TAG=latest TARGET_IMAGE=transifex-delivery-devel
+	make _build TARGET_IMAGE=transifex-delivery-devel
 
 build_prod:
-	make _build TARGET_TAG=latest TARGET_IMAGE=transifex-delivery
+	make _build TARGET_IMAGE=transifex-delivery
 
 _build:
 	docker build \


### PR DESCRIPTION
Remove the `TARGET_TAG` variable from the Makefile commands
`build` and `build_prod`. This allows to pass a custom `TARGET_TAG`
when building the image. It still defaults to `latest`.