### PR TITLE
Analytics v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,11 +296,10 @@ Response body (fail):
 
 ## Analytics
 
-Endpoint to get usage analytics, per language, SDK and unique anonymized visitors.
-Aggregated per day or month.
+Endpoint to get usage analytics, per language, SDK and unique anonymized clients.
 
 ```
-GET /analytics?filter[since]=<YYYY-MM-DD>&filter[until]=<YYYY-MM-DD>[&filter[aggr]=day|month]
+GET /analytics?filter[since]=<YYYY-MM-DD>&filter[until]=<YYYY-MM-DD>
 
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
@@ -316,10 +315,22 @@ Response body:
       <sdk-version>: <number of hits>,
       ...
     },
-    visitors: <number of unique visitors>,
+    clients: <number of unique clients>,
     date: <YYYY-MM-DD or YYYY-MM>,
   }, ...],
-  meta: {},
+  meta: {
+    total: {
+      languages: {
+        <lang-code>: <total number of hits>,
+        ...
+      },
+      sdks: {
+        <sdk-version>: <total number of hits>,
+        ...
+      },
+      clients: <total number of unique clients>,
+    },
+  },
 }
 ```
 

--- a/src/queue/worker.js
+++ b/src/queue/worker.js
@@ -6,8 +6,6 @@ const registry = require('../services/registry');
 const syncer = require('../services/syncer/data');
 
 const registryExpireSec = config.get('registry:expire_min') * 60;
-const hasAnalytics = config.get('analytics:enabled');
-const analyticsRetentionSec = config.get('analytics:retention_days') * 24 * 60 * 60;
 
 /**
  * Pull content from API syncer job
@@ -39,14 +37,6 @@ async function syncerPull(job) {
       location,
       cacheKey,
     }, registryExpireSec);
-    // store valid credentials for analytics endpoints
-    if (hasAnalytics) {
-      await registry.set(
-        `analyticsauth:${token.project_token}`,
-        md5(token.original),
-        analyticsRetentionSec,
-      );
-    }
   } catch (e) {
     // gracefully handle 4xx errors and store them in cache
     if (e.status && e.status >= 400 && e.status < 500) {

--- a/src/routes/invalidate.js
+++ b/src/routes/invalidate.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const express = require('express');
-const validateHeader = require('../middlewares/headers');
+const { validateHeader, validateAuth } = require('../middlewares/headers');
 const logger = require('../logger');
 const cache = require('../services/cache');
 const registry = require('../services/registry');
@@ -9,6 +9,7 @@ const router = express.Router();
 
 router.post('/',
   validateHeader('private'),
+  validateAuth,
   async (req, res) => {
     try {
       const token = req.token.project_token;

--- a/src/routes/languages.js
+++ b/src/routes/languages.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const validateHeader = require('../middlewares/headers');
+const { validateHeader } = require('../middlewares/headers');
 const utils = require('../helpers/utils');
 
 const router = express.Router();

--- a/src/services/registry/index.js
+++ b/src/services/registry/index.js
@@ -131,10 +131,18 @@ function incr(key, increment, expireSec) {
   });
 }
 
+/**
+ * Add value to set
+ *
+ * @param {String} key
+ * @param {*} value
+ * @param {Number} expireSec (optional)
+ * @returns {Promise<Boolean>} - whether a new value was added
+ */
 function addToSet(key, value, expireSec) {
   return new Promise((resolve, reject) => {
     const stringValue = JSON.stringify(value);
-    client.sadd(keyToRedis(key), stringValue, (err) => {
+    client.sadd(keyToRedis(key), stringValue, (err, count) => {
       if (err) {
         reject(err);
       } else if (expireSec > 0) {
@@ -142,29 +150,42 @@ function addToSet(key, value, expireSec) {
           if (err2) {
             reject(err2);
           } else {
-            resolve();
+            resolve(count > 0);
           }
         });
       } else {
-        resolve();
+        resolve(count > 0);
       }
     });
   });
 }
 
+/**
+ * Remove value from set
+ *
+ * @param {String} key
+ * @param {*} value
+ * @returns {Promise<Boolean>} - whether an existing value was removed
+ */
 function removeFromSet(key, value) {
   return new Promise((resolve, reject) => {
     const stringValue = JSON.stringify(value);
-    client.srem(keyToRedis(key), stringValue, (err) => {
+    client.srem(keyToRedis(key), stringValue, (err, count) => {
       if (err) {
         reject(err);
       } else {
-        resolve();
+        resolve(count > 0);
       }
     });
   });
 }
 
+/**
+ * Get all values from set
+ *
+ * @param {String} key
+ * @returns {Promise<Array>}
+ */
 function listSet(key) {
   return new Promise((resolve, reject) => {
     client.smembers(keyToRedis(key), (err, members) => {
@@ -188,6 +209,12 @@ function listSet(key) {
   });
 }
 
+/**
+ * Count number of values in set
+ *
+ * @param {String} key
+ * @returns {Promise<Number>}
+ */
 function countSet(key) {
   return new Promise((resolve, reject) => {
     client.scard(keyToRedis(key), (err, count) => {
@@ -200,6 +227,13 @@ function countSet(key) {
   });
 }
 
+/**
+ * Check if value is in set
+ *
+ * @param {String} key
+ * @param {*} value
+ * @returns {Promise<Boolean>}
+ */
 function isSetMember(key, value) {
   return new Promise((resolve, reject) => {
     const stringValue = JSON.stringify(value);

--- a/tests/routes/analytics.spec.js
+++ b/tests/routes/analytics.spec.js
@@ -25,7 +25,7 @@ describe('Analytics', () => {
 
   it('returns daily results', async () => {
     await registry.set(
-      `analyticsauth:${token}`,
+      `auth:${token}`,
       md5(`${token}:secret`),
     );
 
@@ -40,32 +40,15 @@ describe('Analytics', () => {
         languages: {},
         sdks: {},
         date: today,
-        visitors: 0,
+        clients: 0,
       }],
-      meta: {},
-    });
-  });
-
-  it('returns monthly results', async () => {
-    await registry.set(
-      `analyticsauth:${token}`,
-      md5(`${token}:secret`),
-    );
-
-    const today = dayjs().format('YYYY-MM-DD');
-    const res = await req
-      .get(`/analytics?filter[since]=${today}&filter[until]=${today}&filter[aggr]=month`)
-      .set('Authorization', `Bearer ${token}:secret`);
-
-    expect(res.status).to.equal(200);
-    expect(res.body).to.deep.equal({
-      data: [{
-        languages: {},
-        sdks: {},
-        date: dayjs().format('YYYY-MM'),
-        visitors: 0,
-      }],
-      meta: {},
+      meta: {
+        total: {
+          languages: {},
+          sdks: {},
+          clients: 0,
+        },
+      },
     });
   });
 
@@ -80,7 +63,7 @@ describe('Analytics', () => {
 
   it('validates filters', async () => {
     await registry.set(
-      `analyticsauth:${token}`,
+      `auth:${token}`,
       md5(`${token}:secret`),
     );
 
@@ -97,17 +80,11 @@ describe('Analytics', () => {
       .get(`/analytics?filter[since]=${today}`)
       .set('Authorization', `Bearer ${token}:secret`);
     expect(res.status).to.equal(400);
-
-    // wrong aggregation filter
-    res = await req
-      .get(`/analytics?filter[since]=${today}&filter[until]=${today}&filter[aggr]=any`)
-      .set('Authorization', `Bearer ${token}:secret`);
-    expect(res.status).to.equal(400);
   });
 
   it('validates date range', async () => {
     await registry.set(
-      `analyticsauth:${token}`,
+      `auth:${token}`,
       md5(`${token}:secret`),
     );
     const res = await req

--- a/tests/services/registry.spec.js
+++ b/tests/services/registry.spec.js
@@ -54,17 +54,17 @@ describe('Registry', () => {
   });
 
   it('adds to set', async () => {
-    await registry.addToSet('test:add_to_set', 'a');
-    await registry.addToSet('test:add_to_set', 'a');
-    await registry.addToSet('test:add_to_set', 'b');
+    expect(await registry.addToSet('test:add_to_set', 'a')).to.equal(true);
+    expect(await registry.addToSet('test:add_to_set', 'a')).to.equal(false);
+    expect(await registry.addToSet('test:add_to_set', 'b')).to.equal(true);
     expect(await registry.countSet('test:add_to_set')).to.equal(2);
   });
 
   it('removes from set', async () => {
     await registry.addToSet('test:rem_from_set', 'a');
     await registry.addToSet('test:rem_from_set', 'b');
-    await registry.removeFromSet('test:rem_from_set', 'c');
-    await registry.removeFromSet('test:rem_from_set', 'b');
+    expect(await registry.removeFromSet('test:rem_from_set', 'c')).to.equal(false);
+    expect(await registry.removeFromSet('test:rem_from_set', 'b')).to.equal(true);
     expect(await registry.countSet('test:rem_from_set')).to.equal(1);
   });
 


### PR DESCRIPTION
It seems that Python Native SDK is hitting aggressively CDS creating false positives on the traffic of the service.
This PR updates analytics to track the hits of unique visitors per day instead of actual page hits.

It also fixes an issue with secret key authentication both on analytics and invalidate endpoints. From now on, a successful push of source content is required in order for credentials to be stored in CDS and then subsequently be used for invalidation and analytics.