### PR TITLE
Make `parseSourceStringForAPI` work with string

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/checkout@v2
     - run: make build
     - run: make eslint
-    - run: make test
+    - run: make ci-tests

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ up:
 eslint:
 	docker-compose run --rm transifex-delivery npm run eslint
 
-test:
+ci-tests:
 	docker-compose run --rm transifex-delivery npm test
+
+test:
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm transifex-delivery npm test
 
 stop:
 	docker-compose stop

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Request body:
     <key>: {
       string: <source string>,
       meta: {
-        context: <array>
+        context: <string>
         developer_comment: <string>,
         character_limit: <number>,
         tags: <array>,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transifex-delivery",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Transifex Content Delivery Service",
   "keywords": [
     "transifex",

--- a/src/services/syncer/strategies/transifex/utils/transformer.js
+++ b/src/services/syncer/strategies/transifex/utils/transformer.js
@@ -181,7 +181,7 @@ function parseSourceStringForKeyLookup(payload) {
  * @param {Object} payload The requested payload
  * @returns {Object} An object with the appropriate payload format
  * {
- *   context: [<context>, <context>],
+ *   context: <string>,
  *   key: <string_key>,
  *   strings: {
  *     other: <string>,
@@ -193,7 +193,6 @@ function parseSourceStringForAPI(key, payload) {
   const [variableName, strings] = explodePlurals(payload.string || '');
   const result = {
     key,
-    context: _.get(payload, 'meta.context') || [],
     strings,
     pluralized: !!variableName,
   };
@@ -210,6 +209,13 @@ function parseSourceStringForAPI(key, payload) {
 
   if (_.get(payload, 'meta.occurrences')) {
     result.occurrences = _.join(payload.meta.occurrences, ',');
+  }
+
+  const context = _.get(payload, 'meta.context') || '';
+  if (Array.isArray(context)) {
+    result.context = _.join(context, ':');
+  } else {
+    result.context = context;
   }
 
   return result;

--- a/tests/services/syncer/strategies/transifex/helpers/api.js
+++ b/tests/services/syncer/strategies/transifex/helpers/api.js
@@ -169,7 +169,7 @@ const getPushSourceContent = () => JSON.parse(`{
     "somekey": {
       "string": "I am a string",
       "meta": {
-        "context": ["context1", "context2"],
+        "context": "context1:context2",
         "developer_comment": "Some notes",
         "tags": ["tag1", "tag2"],
         "character_limit": 33,
@@ -179,7 +179,7 @@ const getPushSourceContent = () => JSON.parse(`{
     "hello_world": {
       "string": "{cnt, plural, one {hello} other {world}}",
       "meta": {
-        "context": [ "frontpage", "footer", "verb" ],
+        "context": "frontpage:footer:verb",
         "character_limit": 100,
         "tags": [ "foo", "bar" ],
         "developer_comment": "Wrapped in a 30px width div",
@@ -194,11 +194,7 @@ const getSourceString = () => JSON.parse(`{
         "attributes": {
           "appearance_order": 0,
           "character_limit": 100,
-          "context": [
-            "frontpage",
-            "footer",
-            "verb"
-          ],
+          "context": "frontpage:footer:verb",
           "date_created": "XXXX-XX-XXTXX:XX:XXZ",
           "developer_comment": "Wrapped in a 30px width div",
           "instructions": "Please use causal language for translations.",

--- a/tests/services/syncer/strategies/transifex/utils/transformer.spec.js
+++ b/tests/services/syncer/strategies/transifex/utils/transformer.spec.js
@@ -7,6 +7,7 @@ const { getLanguageInfo } = require('../../../../../../src/helpers/languages');
 const transformer = require('../../../../../../src/services/syncer/strategies/transifex/utils/transformer');
 const api = require('../helpers/api');
 
+
 describe('Transformer', () => {
   it('should parse languages', () => {
     const response = api.getTargetLanguages();
@@ -96,7 +97,6 @@ describe('Transformer', () => {
     const key = 'somekey';
     const data = payload[key];
     const result = transformer.parseSourceStringForAPI(key, data);
-
     expect(result).to.eql({
       context: data.meta.context,
       developer_comment: data.meta.developer_comment,
@@ -120,7 +120,7 @@ describe('Transformer', () => {
     const result = transformer.parseSourceStringForAPI(key, data);
 
     expect(result).to.eql({
-      context: [],
+      context: '',
       key,
       strings: {
         other: '',
@@ -159,11 +159,11 @@ describe('Transformer', () => {
           other: 'world',
         },
         pluralized: true,
-        context: ['frontpage', 'footer', 'verb'],
+        context: 'frontpage:footer:verb',
         tags: ['foo', 'bar'],
         developer_comment: 'Wrapped in a 30px width div',
         character_limit: 100,
-        occurrences: '/my_project/templates/frontpage/hello.html:30',
+        occurrences: "/my_project/templates/frontpage/hello.html:30",
       },
       payload: {
         character_limit: 100,


### PR DESCRIPTION
Make `parseSourceStringForAPI` work with string.

The change takes place due to the work in [api-v3](https://github.com/transifex/transifex-api-v3/pull/436) where the `context` attribute's type from `list` to `string`.