### PR TITLE
Add trust secret authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ TX__APP__PORT=10300
 # Express "Trust proxy" setting to detect client IP
 TX__SETTINGS__TRUST_PROXY=1
 
+# Optional secret for trusting communication between CDS and Transifex
+# Used for requests supporting the X-TRANSIFEX-TRUST-SECRET authentication
+# header
+TX__SETTINGS__TRUST_SECRET=supersecret
+
 # Max-age header for cached responses
 TX__SETTINGS__CACHE_TTL=1800 (in seconds)
 
@@ -282,6 +287,12 @@ POST /invalidate/<lang-code>
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
 
+or
+
+Authorization: Bearer <project-token>
+X-TRANSIFEX-TRUST-SECRET: <transifex-secret>
+Content-Type: application/json; charset=utf-8
+
 Request body:
 {}
 
@@ -309,6 +320,12 @@ POST /purge/<lang-code>
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
 
+or
+
+Authorization: Bearer <project-token>
+X-TRANSIFEX-TRUST-SECRET: <transifex-secret>
+Content-Type: application/json; charset=utf-8
+
 Request body:
 {}
 
@@ -333,6 +350,12 @@ Endpoint to get usage analytics, per language, SDK and unique anonymized clients
 GET /analytics?filter[since]=<YYYY-MM-DD>&filter[until]=<YYYY-MM-DD>
 
 Authorization: Bearer <project-token>:<secret>
+Content-Type: application/json; charset=utf-8
+
+or
+
+Authorization: Bearer <project-token>
+X-TRANSIFEX-TRUST-SECRET: <transifex-secret>
 Content-Type: application/json; charset=utf-8
 
 Response body:

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -10,6 +10,7 @@ settings:
   autosync_min: 60
   disk_storage_path: '/tmp'
   token_whitelist: ''
+  trust_secret: ''
   auth_cache_min: 30
   syncer: transifex
   cache: redis

--- a/config/test.yml
+++ b/config/test.yml
@@ -18,3 +18,6 @@ cache:
 queue:
   name: 'test:sync'
   workers: 0
+
+settings:
+  trust_secret: 'txsecret'

--- a/src/routes/analytics.js
+++ b/src/routes/analytics.js
@@ -20,7 +20,7 @@ router.get('/',
       next();
     }
   },
-  validateHeader('private'),
+  validateHeader('trust'),
   validateAuth,
   async (req, res) => {
     const filterQuery = req.query.filter || {};

--- a/src/routes/invalidate.js
+++ b/src/routes/invalidate.js
@@ -8,7 +8,7 @@ const registry = require('../services/registry');
 const router = express.Router();
 
 router.post('/:lang_code',
-  validateHeader('private'),
+  validateHeader('trust'),
   validateAuth,
   async (req, res) => {
     try {
@@ -57,7 +57,7 @@ router.post('/:lang_code',
   });
 
 router.post('/',
-  validateHeader('private'),
+  validateHeader('trust'),
   validateAuth,
   async (req, res) => {
     try {

--- a/src/routes/purge.js
+++ b/src/routes/purge.js
@@ -8,7 +8,7 @@ const registry = require('../services/registry');
 const router = express.Router();
 
 router.post('/:lang_code',
-  validateHeader('private'),
+  validateHeader('trust'),
   validateAuth,
   async (req, res) => {
     try {
@@ -37,7 +37,7 @@ router.post('/:lang_code',
   });
 
 router.post('/',
-  validateHeader('private'),
+  validateHeader('trust'),
   validateAuth,
   async (req, res) => {
     try {

--- a/tests/routes/analytics.spec.js
+++ b/tests/routes/analytics.spec.js
@@ -14,7 +14,7 @@ const token = '1/abcd';
 const key = `${token}:en:content`;
 const content = JSON.stringify({ foo: 'bar' });
 
-describe('Analytics', () => {
+describe('Analytics as user', () => {
   beforeEach(async () => {
     await populateRegistry(key, content);
   });
@@ -91,5 +91,55 @@ describe('Analytics', () => {
       .get('/analytics?filter[since]=2000-01-01&filter[until]=2021-01-01')
       .set('Authorization', `Bearer ${token}:secret`);
     expect(res.status).to.equal(400);
+  });
+});
+
+describe('Analytics as Transifex', () => {
+  beforeEach(async () => {
+    await populateRegistry(key, content);
+  });
+
+  afterEach(async () => {
+    await resetRegistry();
+  });
+
+  it('returns daily results', async () => {
+    await registry.set(
+      `auth:${token}`,
+      md5(`${token}:secret`),
+    );
+
+    const today = dayjs().format('YYYY-MM-DD');
+    const res = await req
+      .get(`/analytics?filter[since]=${today}&filter[until]=${today}`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Transifex-Trust-Secret', 'txsecret');
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.equal({
+      data: [{
+        languages: {},
+        sdks: {},
+        date: today,
+        clients: 0,
+      }],
+      meta: {
+        total: {
+          languages: {},
+          sdks: {},
+          clients: 0,
+        },
+      },
+    });
+  });
+
+  it('authenticates', async () => {
+    const today = dayjs().format('YYYY-MM-DD');
+    const res = await req
+      .get(`/analytics?filter[since]=${today}&filter[until]=${today}`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Transifex-Trust-Secret', 'invalid');
+
+    expect(res.status).to.equal(403);
   });
 });

--- a/tests/routes/purge.spec.js
+++ b/tests/routes/purge.spec.js
@@ -16,7 +16,7 @@ const content = JSON.stringify({ foo: 'bar' });
 const etag = 'abcd';
 const cacheKey = `${key}:${etag}`;
 
-describe('Purge', () => {
+describe('Purge as user', () => {
   beforeEach(async () => {
     await populateRegistry(key, content);
     await registry.set(
@@ -80,6 +80,79 @@ describe('Purge', () => {
     const res = await req
       .post('/purge')
       .set('Authorization', `Bearer ${token}_invalid:secret`);
+
+    expect(res.status).to.equal(403);
+  });
+});
+
+describe('Purge as Transifex', () => {
+  beforeEach(async () => {
+    await populateRegistry(key, content);
+    await registry.set(
+      `auth:${token}`,
+      md5(`${token}:secret`),
+    );
+  });
+
+  afterEach(async () => {
+    await registry.del(`auth:${token}`);
+    await resetRegistry();
+  });
+
+  it('should purge all languages', async () => {
+    const res = await req
+      .post('/purge')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Transifex-Trust-Secret', 'txsecret');
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.contain({
+      status: 'success',
+      token,
+    });
+    expect(res.body.count).to.be.greaterThan(0);
+    expect(await cache.getContent(cacheKey)).to.deep.equal({
+      data: null,
+    });
+  });
+
+  it('should purge specific languages', async () => {
+    const res = await req
+      .post('/purge/en')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Transifex-Trust-Secret', 'txsecret');
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.contain({
+      status: 'success',
+      token,
+    });
+    expect(res.body.count).to.be.greaterThan(0);
+    expect(await cache.getContent(cacheKey)).to.deep.equal({
+      data: null,
+    });
+  });
+
+  it('should not purge non-existing language', async () => {
+    const res = await req
+      .post('/purge/abcd')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Transifex-Trust-Secret', 'txsecret');
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.contain({
+      status: 'success',
+      token,
+    });
+    expect(res.body.count).to.equal(0);
+  });
+
+  it('should validate token', async () => {
+    await registry.del(`auth:${token}`);
+    const res = await req
+      .post('/purge')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Transifex-Trust-Secret', 'invalid');
 
     expect(res.status).to.equal(403);
   });


### PR DESCRIPTION
Add a way to invalidate cache and get analytics data from CDS by trusting credentials between Transifex and CDS.