### PR TITLE
Append tags to existing strings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,17 @@ Response body:
 
 Push source content.
 
+**Purge content**
+
 If `purge: true` in `meta` object, then replace the entire resource content with the pushed content of this request.
 
 If `purge: false` in `meta` object (the default), then append the source content of this request to the existing resource content.
+
+**Replace tags**
+
+If `override_tags: true` in `meta` object, then replace the existing string tags with the tags of this request.
+
+If `override_tags: false` in `meta` object (the default), then append tags from source content to tags of existing strings instead of overwriting them.
 
 ```
 POST /content
@@ -228,7 +236,8 @@ Request body:
     <key>: { .. }
   },
   meta: {
-    purge: <boolean>
+    purge: <boolean>,
+    override_tags: <boolean>
   }
 }
 

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -11,6 +11,7 @@ const PUSH_SOURCE_CONTENT_SCHEMA = joi.object().keys({
     .required(),
   meta: joi.object().keys({
     purge: joi.boolean(),
+    override_tags: joi.boolean(),
   }),
 });
 

--- a/src/services/syncer/strategies/transifex/utils/api_payloads.js
+++ b/src/services/syncer/strategies/transifex/utils/api_payloads.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 
+const PATCH_ATTRIBUTES = ['character_limit', 'tags'];
+
 function getPushStringPayload(resourceId, attributes) {
   return {
     attributes,
@@ -17,7 +19,7 @@ function getPushStringPayload(resourceId, attributes) {
 
 function getPatchStringPayload(stringId, attributes) {
   return {
-    attributes: _.omit(attributes, ['context', 'key', 'strings', 'pluralized']),
+    attributes: _.pick(attributes, PATCH_ATTRIBUTES),
     id: stringId,
     type: 'resource_strings',
   };
@@ -30,8 +32,18 @@ function getDeleteStringPayload(stringId) {
   };
 }
 
+function stringNeedsUpdate(attributes, existingAttributes) {
+  const filteredAttrs = _.filter(PATCH_ATTRIBUTES,
+    (attr) => !_.isUndefined(attributes[attr]));
+  return !_.isEqual(
+    _.pick(attributes, filteredAttrs),
+    _.pick(existingAttributes, filteredAttrs),
+  );
+}
+
 module.exports = {
   getPushStringPayload,
   getPatchStringPayload,
   getDeleteStringPayload,
+  stringNeedsUpdate,
 };


### PR DESCRIPTION
- Update push source content to append tags to existing string instead of replacing them
- Update patch Transifex strategy to properly detect if a string is eligible for update, skip otherwise