### PR TITLE
Provide keepAliveTimeout setting for the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ TX__SETTINGS__SYNCER=transifex
 # Cache strategy (redis, s3)
 TX__SETTINGS__CACHE=redis
 
+# Number of seconds to keep alive idle connections
+TX__SETTINGS__KEEP_ALIVE_TIMEOUT_SEC=180
+
 # Interval for auto-syncing content and refreshing content cache
 TX__SETTINGS__AUTOSYNC_MIN=60
 

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -14,6 +14,7 @@ settings:
   auth_cache_min: 30
   syncer: transifex
   cache: redis
+  keep_alive_timeout_sec: ''
 
 transifex:
   api_host: https://rest.api.transifex.com

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ if (process.env.TX__NEWRELIC_LICENSE_KEY) {
   require('newrelic');
 }
 
+const { isNumber } = require('lodash');
 const server = require('./server');
 const metrics = require('./middlewares/metrics');
 const config = require('./config');
@@ -12,7 +13,12 @@ const logger = require('./logger');
 // without starting the server itself
 const app = server();
 
-app.listen(config.get('app:port'), () => {
+const attachedApplication = app.listen(config.get('app:port'), () => {
   logger.info(`Listening on port ${config.get('app:port')}!`);
   metrics.metricsServer();
 });
+
+const keepAliveTimeoutSec = config.get('settings:keep_alive_timeout_sec');
+if (isNumber(keepAliveTimeoutSec) && keepAliveTimeoutSec >= 0) {
+  attachedApplication.keepAliveTimeout = keepAliveTimeoutSec * 1000;
+}


### PR DESCRIPTION
This adds a new setting `settings:keep_alive_timeout` or
`TX__SETTINGS__KEEP_ALIVE_TIMEOUT_SEC` that if it is different than the
default value `''` adds a keepAliveTimeout setting to the node server.

This can be really helpful in situations that there is a load balancer
in front of the application and this setting needs to be a bit higher
than the load balancer's idle timeout.