### PR TITLE
Detect optimal push strategy based on content

### DIFF
--- a/src/services/syncer/strategies/transifex/utils/api_urls.js
+++ b/src/services/syncer/strategies/transifex/utils/api_urls.js
@@ -10,6 +10,7 @@ const TRANSIFEX_API_KEYS = {
   LANGUAGE_CODE: 'l:language_code',
   RESOURCE_SLUG: 'r:resource_slug',
   FILTER_TAGS: 'f:tags',
+  FILTER_KEY: 'f:key',
 };
 
 // Keep in one place the APIs entity keys
@@ -19,6 +20,7 @@ const ENTITY_IDS = {
   RESOURCE: 'o:organization_slug:p:project_slug:r:resource_slug',
   LANGUAGE: 'l:language_code',
   TAGS: 'f:tags',
+  KEY: 'f:key',
 };
 
 const TRANSIFEX_API_URLS = {
@@ -34,6 +36,10 @@ const TRANSIFEX_API_URLS = {
   RESOURCE_STRINGS: '/resource_strings',
   GET_RESOURCE_STRINGS: '/resource_strings?'
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
+    + `limit=${PAGE_LIMIT}`,
+  GET_RESOURCE_STRINGS_FILTER_KEY: '/resource_strings?'
+    + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
+    + `filter[key]=${ENTITY_IDS.KEY}&`
     + `limit=${PAGE_LIMIT}`,
   GET_RESOURCE_STRINGS_FILTER_TAGS: '/resource_strings?'
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
@@ -66,7 +72,12 @@ function getHeaders(token, isBulk) {
   };
 }
 
+function getPageSize() {
+  return PAGE_LIMIT;
+}
+
 module.exports = {
   getUrl,
   getHeaders,
+  getPageSize,
 };

--- a/tests/routes/content.spec.js
+++ b/tests/routes/content.spec.js
@@ -64,6 +64,7 @@ describe('/content', () => {
         data: [{
           attributes: {
             slug: 'rslug',
+            string_count: '10',
           },
         }],
       }));

--- a/tests/routes/languages.spec.js
+++ b/tests/routes/languages.spec.js
@@ -55,6 +55,7 @@ describe('/languages', () => {
         data: [{
           attributes: {
             slug: 'rslug',
+            string_count: '10',
           },
         }],
       }));


### PR DESCRIPTION
When not purging during push, detect the minimum requests required to get current content before comparing it with content to be pushed using the following two strategies:
1. Get the whole resource strategy, getting all strings in batches of 1000
2. Query specific keys

For example, pushing 10 strings in a resource of 150K strings would require the following requests:
1. 150 requests to get the whole resource
2. 10 requests to get the status the 10 strings

So in that case, the second strategy would be used.