### PR TITLE
Add limit in resource translations

### DIFF
--- a/src/services/syncer/strategies/transifex/utils/api_urls.js
+++ b/src/services/syncer/strategies/transifex/utils/api_urls.js
@@ -28,11 +28,13 @@ const TRANSIFEX_API_URLS = {
   RESOURCE_TRANSLATIONS: '/resource_translations',
   GET_RESOURCE_TRANSLATIONS: '/resource_translations?'
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
-    + `filter[language]=${ENTITY_IDS.LANGUAGE}&include=resource_string`,
+    + `filter[language]=${ENTITY_IDS.LANGUAGE}&include=resource_string&`
+    + `limit=${PAGE_LIMIT}`,
   GET_RESOURCE_TRANSLATIONS_FILTER_TAGS: '/resource_translations?'
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
     + `filter[language]=${ENTITY_IDS.LANGUAGE}&include=resource_string&`
-    + `filter[resource_string][tags][all]=${ENTITY_IDS.TAGS}`,
+    + `filter[resource_string][tags][all]=${ENTITY_IDS.TAGS}&`
+    + `limit=${PAGE_LIMIT}`,
   RESOURCE_STRINGS: '/resource_strings',
   GET_RESOURCE_STRINGS: '/resource_strings?'
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`

--- a/tests/routes/content.spec.js
+++ b/tests/routes/content.spec.js
@@ -21,7 +21,8 @@ const urls = {
   resources: '/resources?filter[project]=o:oslug:p:pslug',
   languages: '/projects/o:oslug:p:pslug/languages',
   get_translations: '/resource_translations?filter[resource]='
-    + 'o:oslug:p:pslug:r:rslug&filter[language]=l:lcode&include=resource_string',
+    + 'o:oslug:p:pslug:r:rslug&filter[language]=l:lcode&include=resource_string&'
+    + `limit=${config.get('transifex:page_limit')}`,
   source_strings: '/resource_strings?filter[resource]='
     + 'o:oslug:p:pslug:r:rslug&'
     + `limit=${config.get('transifex:page_limit')}`,

--- a/tests/services/syncer/strategies/transifex/data.spec.js
+++ b/tests/services/syncer/strategies/transifex/data.spec.js
@@ -30,7 +30,8 @@ const urls = {
   resources: '/resources?filter[project]=o:oslug:p:pslug',
   languages: '/projects/o:oslug:p:pslug/languages',
   translations: '/resource_translations?filter[resource]=o:oslug:p:pslug'
-    + ':r:rslug&filter[language]=l:lcode&include=resource_string',
+    + ':r:rslug&filter[language]=l:lcode&include=resource_string&'
+    + `limit=${config.get('transifex:page_limit')}`,
   source_strings: '/resource_strings?filter[resource]='
     + 'o:oslug:p:pslug:r:rslug&'
     + `limit=${config.get('transifex:page_limit')}`,

--- a/tests/services/syncer/strategies/transifex/utils/api_urls.spec.js
+++ b/tests/services/syncer/strategies/transifex/utils/api_urls.spec.js
@@ -13,7 +13,8 @@ describe('API urls helper', () => {
     });
     expect(result).to.equal(`${config.get('transifex:api_host')}/resource_translations?`
       + 'filter[resource]=o:oslug:p:pslug:r:rslug&filter[language]=l:lcode'
-      + '&include=resource_string');
+      + '&include=resource_string&'
+      + `limit=${config.get('transifex:page_limit')}`);
   });
 
   it('should return correct auth headers', () => {


### PR DESCRIPTION
Gets resource translations with a limit of 1000 instead of 150 for performance reasons.