### PR TITLE
Enable async content upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,15 +363,19 @@ Request body:
 Response status: 200
 Response body (success):
 {
-  status: 'success',
-  token: <project-token>,
-  count: <number of resources invalidated>,
+  data: {
+    status: 'success',
+    token: <project-token>,
+    count: <number of resources invalidated>,
+  },
 }
 
 Response status: 500
 Response body (fail):
 {
-  status: 'failed',
+  data: {
+    status: 'failed',
+  },
 }
 ```
 
@@ -400,15 +404,19 @@ Request body:
 Response status: 200
 Response body (success):
 {
-  status: 'success',
-  token: <project-token>,
-  count: <number of resources purged>,
+  data: {
+    status: 'success',
+    token: <project-token>,
+    count: <number of resources purged>,
+  }
 }
 
 Response status: 500
 Response body (fail):
 {
-  status: 'failed',
+  data: {
+    status: 'failed',
+  },
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ TX__SETTINGS__PULL_SUCCESS_CACHE_MIN=10080
 # Minutes to cache failed pulls in the registry
 TX__SETTINGS__PULL_ERROR_CACHE_MIN=15
 
+# Minutes to cache job status in registry
+TX__SETTINGS__JOB_STATUS_CACHE_MIN=480
+
 # Redis host
 TX__REDIS__HOST=redis://transifex-delivery-redis
 
@@ -149,6 +152,7 @@ GET /languages
 
 Authorization: Bearer <project-token>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 Response status: 202
 - Content not ready, queued for download from Transifex
@@ -186,6 +190,7 @@ GET /content/<lang-code>?filter[tags]=tag1,tag2
 
 Authorization: Bearer <project-token>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 Response status: 202
 - Content not ready, queued for download from Transifex
@@ -233,6 +238,7 @@ POST /content
 
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 Request body:
 {
@@ -255,15 +261,15 @@ Request body:
   }
 }
 
-Response status: 200
+Response status: 202
 Response body:
 {
-  created: <number>,
-  updated: <number>,
-  skipped: <number>,
-  deleted: <number>,
-  failed: <number>,
-  errors: [..],
+  data: {
+    id: <string>,
+    links: {
+      job: <string>
+    }
+  }
 }
 
 Response status: 429
@@ -271,6 +277,62 @@ Response body:
 {
   status: 429,
   message: 'Another content upload is already in progress',
+}
+```
+
+### Job status
+
+Get job status for push source content action:
+- If "status" field is "pending" or "processing", you should check this endpoint again later
+- If "status" field is "failed", then you should check for "errors"
+- If "status" field is "completed", then you should check for "details" and "errors"
+
+```
+GET /jobs/content/<id>
+
+Authorization: Bearer <project-token>:<secret>
+Content-Type: application/json; charset=utf-8
+Accept-version: v2
+
+Response status: 200
+Response body:
+{
+  data: {
+    status: "pending",
+  },
+}
+
+Response status: 200
+Response body:
+{
+  data: {
+    status: "processing",
+  },
+}
+
+Response status: 200
+Response body:
+{
+  data: {
+    details: {
+      created: <number>,
+      updated: <number>,
+      skipped: <number>,
+      deleted: <number>,
+      failed: <number>
+    }
+    errors: [..],
+    status: "completed",
+  },
+}
+
+Response status: 200
+Response body:
+{
+  data: {
+    errors: [..],
+    status: "failed",
+  },
 }
 ```
 
@@ -286,12 +348,14 @@ POST /invalidate/<lang-code>
 
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 or
 
 Authorization: Bearer <project-token>
 X-TRANSIFEX-TRUST-SECRET: <transifex-secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 Request body:
 {}
@@ -321,12 +385,14 @@ POST /purge/<lang-code>
 
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 or
 
 Authorization: Bearer <project-token>
 X-TRANSIFEX-TRUST-SECRET: <transifex-secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 Request body:
 {}
@@ -355,12 +421,14 @@ GET /analytics?filter[since]=<YYYY-MM-DD>&filter[until]=<YYYY-MM-DD>
 
 Authorization: Bearer <project-token>:<secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 or
 
 Authorization: Bearer <project-token>
 X-TRANSIFEX-TRUST-SECRET: <transifex-secret>
 Content-Type: application/json; charset=utf-8
+Accept-version: v2
 
 Response status: 200
 Response body:

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -10,6 +10,7 @@ settings:
   push_throttle_timeout_min: 10
   pull_success_cache_min: 10080
   pull_error_cache_min: 15
+  job_status_cache_min: 480
   cache_ttl: 1800
   autosync_min: 60
   disk_storage_path: '/tmp'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "transifex-delivery",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@sentry/node": "^6.9.0",
-        "aws-sdk": "^2.946.0",
+        "aws-sdk": "^2.948.0",
         "axios": "^0.21.1",
         "axios-retry": "^3.1.9",
         "body-parser": "^1.19.0",
-        "bull": "^3.23.3",
+        "bull": "^3.26.0",
         "chai-http": "^4.3.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -37,7 +37,7 @@
       },
       "devDependencies": {
         "chai": "^4.3.4",
-        "eslint": "^7.30.0",
+        "eslint": "^7.31.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.23.4",
         "mocha": "^9.0.2",
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -1384,9 +1384,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/aws-sdk": {
-      "version": "2.946.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.946.0.tgz",
-      "integrity": "sha512-d0fbVNHdpoeszGUcxOV8m+/kLNxUfKP5QsGwaRjcQfvEokFmvdKsvw87LhepFOa00NaI4J3jt8AbsX4mvmcChg==",
+      "version": "2.948.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.948.0.tgz",
+      "integrity": "sha512-UJaCwccNaNNFtbhlvg+BmcaVWNI7RPonZA16nca0s3O+UnHm5y5H/nN6XpuJp+NUrxrLgTFaztPvjmBp5q6p+g==",
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -1607,9 +1607,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "node_modules/bull": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/bull/-/bull-3.23.3.tgz",
-      "integrity": "sha512-F5RlnfN3CHBVwXQ4EByzI4bau0onGQrKSw6hPrNhvQvTVIrisvkrTIbYe7g3ihlcWN6kjf0aXmN/g/BLSZ0SUA==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/bull/-/bull-3.26.0.tgz",
+      "integrity": "sha512-W1ohwMBApLW9dhKHEwgzr8YnpScTOGC9KtKP2DrvjnWTQFWbaEnKlrDHKp3SJwvAB0C3jDsO579O/Hys/UmAiQ==",
       "dependencies": {
         "cron-parser": "^2.13.0",
         "debuglog": "^1.0.0",
@@ -2452,13 +2452,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
-      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
+      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.2",
+        "@eslint/eslintrc": "^0.4.3",
         "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3317,9 +3317,9 @@
       "dev": true
     },
     "node_modules/globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -7880,9 +7880,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -7897,9 +7897,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -8326,9 +8326,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
@@ -8530,9 +8530,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.946.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.946.0.tgz",
-      "integrity": "sha512-d0fbVNHdpoeszGUcxOV8m+/kLNxUfKP5QsGwaRjcQfvEokFmvdKsvw87LhepFOa00NaI4J3jt8AbsX4mvmcChg==",
+      "version": "2.948.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.948.0.tgz",
+      "integrity": "sha512-UJaCwccNaNNFtbhlvg+BmcaVWNI7RPonZA16nca0s3O+UnHm5y5H/nN6XpuJp+NUrxrLgTFaztPvjmBp5q6p+g==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -8701,9 +8701,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bull": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/bull/-/bull-3.23.3.tgz",
-      "integrity": "sha512-F5RlnfN3CHBVwXQ4EByzI4bau0onGQrKSw6hPrNhvQvTVIrisvkrTIbYe7g3ihlcWN6kjf0aXmN/g/BLSZ0SUA==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/bull/-/bull-3.26.0.tgz",
+      "integrity": "sha512-W1ohwMBApLW9dhKHEwgzr8YnpScTOGC9KtKP2DrvjnWTQFWbaEnKlrDHKp3SJwvAB0C3jDsO579O/Hys/UmAiQ==",
       "requires": {
         "cron-parser": "^2.13.0",
         "debuglog": "^1.0.0",
@@ -9369,13 +9369,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
-      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
+      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.2",
+        "@eslint/eslintrc": "^0.4.3",
         "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -10017,9 +10017,9 @@
       }
     },
     "globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transifex-delivery",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Transifex Content Delivery Service",
   "keywords": [
     "transifex",
@@ -29,11 +29,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sentry/node": "^6.9.0",
-    "aws-sdk": "^2.946.0",
+    "aws-sdk": "^2.948.0",
     "axios": "^0.21.1",
     "axios-retry": "^3.1.9",
     "body-parser": "^1.19.0",
-    "bull": "^3.23.3",
+    "bull": "^3.26.0",
     "chai-http": "^4.3.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.4",
-    "eslint": "^7.30.0",
+    "eslint": "^7.31.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.23.4",
     "mocha": "^9.0.2",

--- a/src/middlewares/headers.js
+++ b/src/middlewares/headers.js
@@ -76,6 +76,12 @@ function validateWhitelist(token) {
 function validateHeader(scope = 'private') {
   return (req, res, next) => {
     try {
+      if (req.headers['accept-version']) {
+        req.version = (req.headers['accept-version'] || '').toLowerCase();
+      } else {
+        req.version = 'v1';
+      }
+
       const parts = req.headers.authorization.split(' ');
       if (parts.length === 2 && parts[0] === 'Bearer') {
         const auth = parts[1].split(':');

--- a/src/queue/index.js
+++ b/src/queue/index.js
@@ -43,11 +43,11 @@ async function addJob(jobId, payload) {
 /**
  * Return the number of jobs in the queue.
  *
- * @returns {Number}
+ * @returns {Object}
  */
 async function countJobs() {
-  const count = await queue.count();
-  return count;
+  const counts = await queue.getJobCounts();
+  return counts;
 }
 
 module.exports = {

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const dayjs = require('dayjs');
 const _ = require('lodash');
+const { v4: uuidv4 } = require('uuid');
 const config = require('../config');
 const { validateHeader } = require('../middlewares/headers');
 const syncer = require('../services/syncer/data');
 const registry = require('../services/registry');
+const queue = require('../queue');
 const md5 = require('../helpers/md5');
 const { cleanTags, routerCacheHelper } = require('../helpers/utils');
 const logger = require('../logger');
@@ -15,87 +17,162 @@ const timeoutMsec = config.get('settings:upload_timeout_min') * 60 * 1000;
 const hasAnalytics = config.get('analytics:enabled');
 const analyticsRetentionSec = config.get('analytics:retention_days') * 24 * 60 * 60;
 const pushThrottleTimeoutSec = config.get('settings:push_throttle_timeout_min') * 60;
+const jobStatusCacheSec = config.get('settings:job_status_cache_min') * 60;
+
+/**
+ * Get language translations
+ *
+ * @param {*} req
+ * @param {*} res
+ */
+async function getContent(req, res) {
+  // pattern is:
+  // - token:lang:content
+  // - token:lang:content[tag1,tag2]
+  let key = `${req.token.project_token}:${req.params.lang_code}:content`;
+
+  // parse tags filter
+  let filter = {};
+  const tags = cleanTags(_.get(req.query, 'filter.tags'));
+  if (tags) {
+    // update filter
+    filter = {
+      tags,
+    };
+    // add tags to key
+    key = `${key}[${tags}]`;
+  }
+  const sentContent = await routerCacheHelper(
+    req, res,
+    key, filter,
+    'getProjectLanguageTranslations', req.params.lang_code,
+  );
+  if (hasAnalytics && sentContent) {
+    const clientId = md5(req.ip || 'unknown');
+
+    const project = req.token.project_token;
+    const lang = req.params.lang_code;
+    const sdkVersion = (req.headers['x-native-sdk'] || 'unknown').replace(/ /g, '-');
+
+    const dateDay = dayjs().format('YYYY-MM-DD');
+    const keyDay = `analytics:${project}:${dateDay}`;
+    if (await registry.addToSet(`${keyDay}:clients`, clientId, analyticsRetentionSec)) {
+      registry.incr(`${keyDay}:lang:${lang}`, 1, analyticsRetentionSec);
+      registry.incr(`${keyDay}:sdk:${sdkVersion}`, 1, analyticsRetentionSec);
+    }
+  }
+}
+
+/**
+ * Push source strings (version 1)
+ *
+ * @param {*} req
+ * @param {*} res
+ */
+async function postContentV1(req, res) {
+  const throttleKey = `throttle:push:${req.token.project_token}`;
+  if (await registry.get(throttleKey)) {
+    res.status(429).json({
+      status: 429,
+      message: 'Another content upload is already in progress',
+    });
+    return;
+  }
+
+  req.setTimeout(timeoutMsec);
+  try {
+    await registry.set(throttleKey, 1, pushThrottleTimeoutSec);
+
+    const data = await syncer
+      .pushSourceContent({ token: req.token }, req.body);
+
+    let status = 200;
+    if (data.errors.length) status = 409;
+
+    res.status(status).json(data);
+  } catch (e) {
+    if (e.status) {
+      if (e.status !== 401) logger.error(e);
+      res.status(e.status).json({
+        status: e.status,
+        message: e.message,
+        details: e.details,
+      });
+    } else {
+      logger.error(e);
+      res.status(500).json({
+        status: 500,
+        message: 'An error occured!',
+      });
+    }
+  } finally {
+    await registry.del(throttleKey);
+  }
+}
+
+/**
+ * Push source strings (version 2)
+ *
+ * @param {*} req
+ * @param {*} res
+ */
+async function postContentV2(req, res) {
+  // authenticate before creating an push job
+  const isAuthenticated = await syncer.verifyCredentials({ token: req.token });
+  if (!isAuthenticated) {
+    res.status(403).json({
+      status: 403,
+      message: 'Forbidden',
+      details: 'Invalid credentials',
+    });
+    return;
+  }
+
+  // create a unique job id based on content
+  const contentHash = md5(JSON.stringify(req.body));
+  const key = `${req.token.project_token}:${contentHash}:push`;
+  const jobId = uuidv4();
+
+  // update job status
+  await registry.set(`job:status:${jobId}`, {
+    data: {
+      status: 'pending',
+    },
+  }, jobStatusCacheSec);
+
+  // add job to queue
+  await queue.addJob(key, {
+    type: 'syncer:push',
+    key,
+    jobId,
+    token: req.token,
+    payload: req.body,
+  });
+
+  // respond
+  res.status(202).json({
+    data: {
+      id: jobId,
+      links: {
+        job: `/jobs/content/${jobId}`,
+      },
+    },
+  });
+}
+
+// ------------- Routes -------------
 
 router.get('/:lang_code',
   validateHeader('public'),
-  async (req, res) => {
-    // pattern is:
-    // - token:lang:content
-    // - token:lang:content[tag1,tag2]
-    let key = `${req.token.project_token}:${req.params.lang_code}:content`;
-
-    // parse tags filter
-    let filter = {};
-    const tags = cleanTags(_.get(req.query, 'filter.tags'));
-    if (tags) {
-      // update filter
-      filter = {
-        tags,
-      };
-      // add tags to key
-      key = `${key}[${tags}]`;
-    }
-    const sentContent = await routerCacheHelper(
-      req, res,
-      key, filter,
-      'getProjectLanguageTranslations', req.params.lang_code,
-    );
-    if (hasAnalytics && sentContent) {
-      const clientId = md5(req.ip || 'unknown');
-
-      const project = req.token.project_token;
-      const lang = req.params.lang_code;
-      const sdkVersion = (req.headers['x-native-sdk'] || 'unknown').replace(/ /g, '-');
-
-      const dateDay = dayjs().format('YYYY-MM-DD');
-      const keyDay = `analytics:${project}:${dateDay}`;
-      if (await registry.addToSet(`${keyDay}:clients`, clientId, analyticsRetentionSec)) {
-        registry.incr(`${keyDay}:lang:${lang}`, 1, analyticsRetentionSec);
-        registry.incr(`${keyDay}:sdk:${sdkVersion}`, 1, analyticsRetentionSec);
-      }
-    }
-  });
+  getContent);
 
 router.post('/',
   validateHeader('private'),
-  async (req, res) => {
-    const throttleKey = `throttle:push:${req.token.project_token}`;
-    if (await registry.get(throttleKey)) {
-      res.status(429).json({
-        status: 429,
-        message: 'Another content upload is already in progress',
-      });
-      return;
-    }
-
-    req.setTimeout(timeoutMsec);
-    try {
-      await registry.set(throttleKey, 1, pushThrottleTimeoutSec);
-
-      const data = await syncer
-        .pushSourceContent({ token: req.token }, req.body);
-
-      let status = 200;
-      if (data.errors.length) status = 409;
-
-      res.status(status).json(data);
-    } catch (e) {
-      if (e.status) {
-        if (e.status !== 401) logger.error(e);
-        res.status(e.status).json({
-          status: e.status,
-          message: e.message,
-          details: e.details,
-        });
-      } else {
-        logger.error(e);
-        res.status(500).json({
-          status: 500,
-          message: 'An error occured!',
-        });
-      }
-    } finally {
-      await registry.del(throttleKey);
+  (req, res) => {
+    if (req.version === 'v2') {
+      postContentV2(req, res);
+    } else {
+      postContentV1(req, res);
     }
   });
 

--- a/src/routes/invalidate.js
+++ b/src/routes/invalidate.js
@@ -43,16 +43,30 @@ router.post('/:lang_code',
         });
         count += 1;
       });
-      res.json({
+      const response = {
         status: 'success',
         token,
         count,
-      });
+      };
+      if (req.version === 'v2') {
+        res.json({
+          data: response,
+        });
+      } else {
+        res.json(response);
+      }
     } catch (e) {
       logger.error(e);
-      res.status(500).json({
+      const response = {
         status: 'failed',
-      });
+      };
+      if (req.version === 'v2') {
+        res.status(500).json({
+          data: response,
+        });
+      } else {
+        res.status(500).json(response);
+      }
     }
   });
 
@@ -106,16 +120,30 @@ router.post('/',
           }
         }
       });
-      res.json({
+      const response = {
         status: 'success',
         token,
         count,
-      });
+      };
+      if (req.version === 'v2') {
+        res.json({
+          data: response,
+        });
+      } else {
+        res.json(response);
+      }
     } catch (e) {
       logger.error(e);
-      res.status(500).json({
+      const response = {
         status: 'failed',
-      });
+      };
+      if (req.version === 'v2') {
+        res.status(500).json({
+          data: response,
+        });
+      } else {
+        res.status(500).json(response);
+      }
     }
   });
 

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const { validateHeader, validateAuth } = require('../middlewares/headers');
+const registry = require('../services/registry');
+
+const router = express.Router();
+
+router.get('/content/:id',
+  validateHeader('trust'),
+  validateAuth,
+  async (req, res) => {
+    const response = await registry.get(`job:status:${req.params.id}`);
+    if (response) {
+      res.json(response);
+    } else {
+      res.status(404).json({
+        status: 404,
+        message: 'Not found',
+        details: 'Invalid job id or job expired',
+      });
+    }
+  });
+
+module.exports = router;

--- a/src/routes/purge.js
+++ b/src/routes/purge.js
@@ -23,16 +23,30 @@ router.post('/:lang_code',
           }
         }
       })()));
-      res.json({
+      const response = {
         status: 'success',
         token,
         count: keys.length,
-      });
+      };
+      if (req.version === 'v2') {
+        res.json({
+          data: response,
+        });
+      } else {
+        res.json(response);
+      }
     } catch (e) {
       logger.error(e);
-      res.json({
+      const response = {
         status: 'failed',
-      });
+      };
+      if (req.version === 'v2') {
+        res.status(500).json({
+          data: response,
+        });
+      } else {
+        res.status(500).json(response);
+      }
     }
   });
 
@@ -52,16 +66,30 @@ router.post('/',
           }
         }
       })()));
-      res.json({
+      const response = {
         status: 'success',
         token,
         count: keys.length,
-      });
+      };
+      if (req.version === 'v2') {
+        res.json({
+          data: response,
+        });
+      } else {
+        res.json(response);
+      }
     } catch (e) {
       logger.error(e);
-      res.json({
+      const response = {
         status: 'failed',
-      });
+      };
+      if (req.version === 'v2') {
+        res.status(500).json({
+          data: response,
+        });
+      } else {
+        res.status(500).json(response);
+      }
     }
   });
 

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ const morgan = require('morgan');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const compression = require('compression');
+const _ = require('lodash');
 const queue = require('./queue');
 const config = require('./config');
 const { version } = require('../package.json');
@@ -15,6 +16,7 @@ const statusRouter = require('./routes/status');
 const invalidateRouter = require('./routes/invalidate');
 const purgeRouter = require('./routes/purge');
 const analyticsRouter = require('./routes/analytics');
+const jobsRouter = require('./routes/jobs');
 
 module.exports = () => {
   // setup express and routes
@@ -50,10 +52,11 @@ module.exports = () => {
 
   // for nagios health check
   app.get('/health', async (req, res) => {
+    const counts = await queue.countJobs();
     res.json({
       version,
       status: 'ok',
-      queue: await queue.countJobs(),
+      jobs: _.pick(counts, 'waiting', 'active', 'delayed'),
     });
   });
 
@@ -66,6 +69,7 @@ module.exports = () => {
   app.use('/invalidate', invalidateRouter);
   app.use('/purge', purgeRouter);
   app.use('/analytics', analyticsRouter);
+  app.use('/jobs', jobsRouter);
 
   app.get('/', (req, res) => res.send('ok'));
 

--- a/src/services/syncer/data.js
+++ b/src/services/syncer/data.js
@@ -97,6 +97,8 @@ async function getProjectLanguageTranslations(options, langCode) {
  *   created: <number>,
  *   updated: <number>,
  *   skipped: <number>,
+ *   deleted: <number>,
+ *   failed: <number>,
  *   errors: [..],
  * }
  */

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -367,6 +367,8 @@ async function deleteSourceContent(token, options) {
  *   created: <a number of strings created>,
  *   failed: <a number of strings failed to be saved>,
  *   skipped: <a number of strings that were skipped>,
+ *   updated: <a number of strings that were updated>,
+ *   deleted: <a number of strings that were deleted>,
  *   errors: <an array with all the errors>,
  * }
  */

--- a/tests/routes/analytics.spec.js
+++ b/tests/routes/analytics.spec.js
@@ -33,6 +33,7 @@ describe('Analytics as user', () => {
     const today = dayjs().format('YYYY-MM-DD');
     const res = await req
       .get(`/analytics?filter[since]=${today}&filter[until]=${today}`)
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
@@ -57,6 +58,7 @@ describe('Analytics as user', () => {
     const today = dayjs().format('YYYY-MM-DD');
     const res = await req
       .get(`/analytics?filter[since]=${today}&filter[until]=${today}`)
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(403);
@@ -73,12 +75,14 @@ describe('Analytics as user', () => {
     // wrong filter
     let res = await req
       .get(`/analytics?filter[any]=${today}&filter[until]=${today}`)
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
     expect(res.status).to.equal(400);
 
     // missing date range filter
     res = await req
       .get(`/analytics?filter[since]=${today}`)
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
     expect(res.status).to.equal(400);
   });
@@ -90,6 +94,7 @@ describe('Analytics as user', () => {
     );
     const res = await req
       .get('/analytics?filter[since]=2000-01-01&filter[until]=2021-01-01')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
     expect(res.status).to.equal(400);
   });
@@ -113,6 +118,7 @@ describe('Analytics as Transifex', () => {
     const today = dayjs().format('YYYY-MM-DD');
     const res = await req
       .get(`/analytics?filter[since]=${today}&filter[until]=${today}`)
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
@@ -138,6 +144,7 @@ describe('Analytics as Transifex', () => {
     const today = dayjs().format('YYYY-MM-DD');
     const res = await req
       .get(`/analytics?filter[since]=${today}&filter[until]=${today}`)
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'invalid');
 

--- a/tests/routes/content.spec.js
+++ b/tests/routes/content.spec.js
@@ -6,6 +6,8 @@ const request = require('supertest');
 const nock = require('nock');
 const dataHelper = require('../services/syncer/strategies/transifex/helpers/api');
 const config = require('../../src/config');
+const registry = require('../../src/services/registry');
+const md5 = require('../../src/helpers/md5');
 const { resetRegistry } = require('../lib');
 const app = require('../../src/server')();
 require('../../src/queue').initialize();
@@ -30,10 +32,14 @@ const urls = {
   resource_strings: '/resource_strings',
 };
 
-describe('/content', () => {
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('GET /content', () => {
   beforeEach(async () => {
-    nock.cleanAll();
     nock(urls.api)
+      .persist()
       .get(urls.organizations)
       .reply(200, JSON.stringify({
         data: [{
@@ -44,6 +50,7 @@ describe('/content', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.projects)
       .reply(200, JSON.stringify({
         data: [{
@@ -61,6 +68,7 @@ describe('/content', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.resources)
       .reply(200, JSON.stringify({
         data: [{
@@ -86,6 +94,7 @@ describe('/content', () => {
     do {
       res = await request(app)
         .get('/content/lcode')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`);
     } while (res.status === 202);
 
@@ -101,6 +110,7 @@ describe('/content', () => {
     do {
       res = await request(app)
         .get('/content/lcode')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`);
     } while (res.status === 202);
 
@@ -125,6 +135,7 @@ describe('/content', () => {
     do {
       res = await request(app)
         .get('/content/en')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`);
     } while (res.status === 202);
 
@@ -149,6 +160,7 @@ describe('/content', () => {
     do {
       res = await request(app)
         .get('/content/lcode')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`);
     } while (res.status === 202);
 
@@ -167,6 +179,7 @@ describe('/content', () => {
     do {
       res = await request(app)
         .get('/content/lcode')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`);
     } while (res.status === 202);
 
@@ -185,6 +198,7 @@ describe('/content', () => {
     do {
       firstRes = await request(app)
         .get('/content/lcode')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`)
         .set('If-None-Match', 'obsolete_value');
     } while (firstRes.status === 202);
@@ -194,10 +208,327 @@ describe('/content', () => {
 
     const res = await request(app)
       .get('/content/lcode')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`)
       .set('If-None-Match', firstRes.headers.etag);
 
     expect(res).to.have.status(304);
+  });
+});
+
+describe('POST /content', () => {
+  beforeEach(async () => {
+    nock(urls.api)
+      .persist()
+      .get(urls.organizations)
+      .reply(200, JSON.stringify({
+        data: [{
+          attributes: {
+            slug: 'oslug',
+          },
+        }],
+      }));
+
+    nock(urls.api)
+      .persist()
+      .get(urls.projects)
+      .reply(200, JSON.stringify({
+        data: [{
+          attributes: {
+            slug: 'pslug',
+          },
+          relationships: {
+            source_language: {
+              data: {
+                id: 'l:en',
+              },
+            },
+          },
+        }],
+      }));
+
+    nock(urls.api)
+      .persist()
+      .get(urls.resources)
+      .reply(200, JSON.stringify({
+        data: [{
+          attributes: {
+            slug: 'rslug',
+            string_count: '10',
+          },
+        }],
+      }));
+
+    await registry.set(
+      `auth:${token}`,
+      md5(`${token}:secret`),
+    );
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+    await resetRegistry();
+  });
+
+  it('should push content', async () => {
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, { data: [], links: {} });
+
+    nock(urls.api).post(urls.resource_strings)
+      .reply(200, {
+        data: [
+          {
+            somekey: 'somevalue',
+          },
+          {
+            someotherkey: 'somevalue',
+          },
+        ],
+      });
+
+    const data = dataHelper.getPushSourceContent();
+
+    let res = await request(app)
+      .post('/content')
+      .set('Accept-version', 'v2')
+      .set('Authorization', `Bearer ${token}:secret`)
+      .send({ data });
+
+    expect(res.status).to.eql(202);
+
+    // poll
+    let status = '';
+    const jobUrl = res.body.data.links.job;
+    while (status !== 'completed') {
+      await sleep(100);
+      res = await request(app)
+        .get(jobUrl)
+        .set('Authorization', `Bearer ${token}:secret`);
+      expect(res.status).to.eql(200);
+      status = res.body.data.status;
+    }
+
+    expect(res.body).to.eqls({
+      data: {
+        details: {
+          created: 2,
+          updated: 0,
+          skipped: 0,
+          deleted: 0,
+          failed: 0,
+        },
+        errors: [],
+        status: 'completed',
+      },
+    });
+  });
+
+  it('should get correct report and errors', async () => {
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, { data: [], links: {} });
+
+    nock(urls.api).post(urls.resource_strings)
+      .reply(400, {
+        errors: [
+          {
+            status: '400',
+            code: 'invalid',
+            title: 'Field `context` is invalid',
+            detail: 'asd is not of type array',
+            source: {
+              pointer: '/data/0/attributes/context',
+            },
+          },
+        ],
+      });
+
+    const data = dataHelper.getPushSourceContent();
+
+    let res = await request(app)
+      .post('/content')
+      .set('Accept-version', 'v2')
+      .set('Authorization', `Bearer ${token}:secret`)
+      .send({ data });
+
+    expect(res.status).to.eql(202);
+
+    // poll
+    let status = '';
+    const jobUrl = res.body.data.links.job;
+    while (status !== 'completed') {
+      await sleep(100);
+      res = await request(app)
+        .get(jobUrl)
+        .set('Authorization', `Bearer ${token}:secret`);
+      expect(res.status).to.eql(200);
+      status = res.body.data.status;
+    }
+
+    expect(res.body).to.eqls({
+      data: {
+        details: {
+          created: 0,
+          updated: 0,
+          skipped: 0,
+          deleted: 0,
+          failed: 2,
+        },
+        errors: [{
+          status: '400',
+          code: 'invalid',
+          title: 'Field `context` is invalid',
+          detail: 'asd is not of type array',
+          source: {
+            pointer: '/data/0/attributes/context',
+          },
+        }],
+        status: 'completed',
+      },
+    });
+  });
+
+  it('should skip already pushed content', async () => {
+    const sourceData = dataHelper.getSourceString();
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, sourceData);
+
+    nock(urls.api).post(urls.resource_strings)
+      .reply(200, {});
+
+    const data = dataHelper.getPushSourceContent();
+
+    let res = await request(app)
+      .post('/content')
+      .set('Accept-version', 'v2')
+      .set('Authorization', `Bearer ${token}:secret`)
+      .send({ data });
+
+    expect(res.status).to.eql(202);
+
+    // poll
+    let status = '';
+    const jobUrl = res.body.data.links.job;
+    while (status !== 'completed') {
+      await sleep(100);
+      res = await request(app)
+        .get(jobUrl)
+        .set('Authorization', `Bearer ${token}:secret`);
+      expect(res.status).to.eql(200);
+      status = res.body.data.status;
+    }
+
+    expect(res.body).to.eqls({
+      data: {
+        details: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          skipped: 1,
+          failed: 0,
+        },
+        errors: [],
+        status: 'completed',
+      },
+    });
+  });
+
+  it('should throw an error if there are no data', async () => {
+    const sourceData = dataHelper.getSourceString();
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, sourceData);
+
+    nock(urls.api)
+      .post(urls.resource_strings)
+      .reply(200, {});
+
+    let res = await request(app)
+      .post('/content')
+      .set('Accept-version', 'v2')
+      .set('Authorization', `Bearer ${token}:secret`)
+      .send({});
+
+    // poll
+    let status = '';
+    const jobUrl = res.body.data.links.job;
+    while (status !== 'failed') {
+      await sleep(100);
+      res = await request(app)
+        .get(jobUrl)
+        .set('Authorization', `Bearer ${token}:secret`);
+      expect(res.status).to.eql(200);
+      status = res.body.data.status;
+    }
+
+    expect(res.body).to.eqls({
+      data: {
+        errors: [
+          'Invalid Payload',
+          {
+            message: '"data" is required',
+            path: ['data'],
+            type: 'any.required',
+            context: {
+              key: 'data',
+              label: 'data',
+            },
+          }],
+        status: 'failed',
+      },
+    });
+  });
+});
+
+describe('POST /content (v1)', () => {
+  beforeEach(async () => {
+    nock(urls.api)
+      .persist()
+      .get(urls.organizations)
+      .reply(200, JSON.stringify({
+        data: [{
+          attributes: {
+            slug: 'oslug',
+          },
+        }],
+      }));
+
+    nock(urls.api)
+      .persist()
+      .get(urls.projects)
+      .reply(200, JSON.stringify({
+        data: [{
+          attributes: {
+            slug: 'pslug',
+          },
+          relationships: {
+            source_language: {
+              data: {
+                id: 'l:en',
+              },
+            },
+          },
+        }],
+      }));
+
+    nock(urls.api)
+      .persist()
+      .get(urls.resources)
+      .reply(200, JSON.stringify({
+        data: [{
+          attributes: {
+            slug: 'rslug',
+            string_count: '10',
+          },
+        }],
+      }));
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+    await resetRegistry();
   });
 
   it('should push content', async () => {

--- a/tests/routes/invalidate.spec.js
+++ b/tests/routes/invalidate.spec.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const request = require('supertest');
+const nock = require('nock');
 const md5 = require('../../src/helpers/md5');
 const registry = require('../../src/services/registry');
 const queue = require('../../src/queue');
@@ -28,6 +29,7 @@ describe('Invalidate as user', () => {
   });
 
   afterEach(async () => {
+    nock.cleanAll();
     sandbox.restore();
     await registry.del(`auth:${token}`);
     await resetRegistry();
@@ -38,6 +40,7 @@ describe('Invalidate as user', () => {
 
     const res = await req
       .post('/invalidate')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
@@ -54,6 +57,7 @@ describe('Invalidate as user', () => {
 
     const res = await req
       .post('/invalidate/en')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
@@ -70,6 +74,7 @@ describe('Invalidate as user', () => {
 
     const res = await req
       .post('/invalidate')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}_invalid:secret`);
 
     expect(res.status).to.equal(403);
@@ -88,6 +93,7 @@ describe('Invalidate as Transifex', () => {
   });
 
   afterEach(async () => {
+    nock.cleanAll();
     sandbox.restore();
     await registry.del(`auth:${token}`);
     await resetRegistry();
@@ -98,6 +104,7 @@ describe('Invalidate as Transifex', () => {
 
     const res = await req
       .post('/invalidate')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
@@ -115,6 +122,7 @@ describe('Invalidate as Transifex', () => {
 
     const res = await req
       .post('/invalidate/en')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
@@ -132,6 +140,7 @@ describe('Invalidate as Transifex', () => {
 
     const res = await req
       .post('/invalidate')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'invalid');
 

--- a/tests/routes/invalidate.spec.js
+++ b/tests/routes/invalidate.spec.js
@@ -44,11 +44,13 @@ describe('Invalidate as user', () => {
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.be.greaterThan(0);
     expect(spy.callCount).to.be.greaterThan(0);
   });
 
@@ -61,11 +63,13 @@ describe('Invalidate as user', () => {
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.equal(1);
     expect(spy.callCount).to.equal(1);
   });
 
@@ -109,11 +113,13 @@ describe('Invalidate as Transifex', () => {
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.be.greaterThan(0);
     expect(spy.callCount).to.be.greaterThan(0);
   });
 
@@ -127,11 +133,13 @@ describe('Invalidate as Transifex', () => {
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.equal(1);
     expect(spy.callCount).to.equal(1);
   });
 

--- a/tests/routes/languages.spec.js
+++ b/tests/routes/languages.spec.js
@@ -20,10 +20,10 @@ const urls = {
   languages: '/projects/o:oslug:p:pslug/languages',
 };
 
-describe('/languages', () => {
+describe('GET /languages', () => {
   beforeEach(async () => {
-    nock.cleanAll();
     nock(urls.api)
+      .persist()
       .get(urls.organizations)
       .reply(200, JSON.stringify({
         data: [{
@@ -34,6 +34,7 @@ describe('/languages', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.projects)
       .reply(200, JSON.stringify({
         data: [{
@@ -51,6 +52,7 @@ describe('/languages', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.resources)
       .reply(200, JSON.stringify({
         data: [{
@@ -91,6 +93,7 @@ describe('/languages', () => {
     do {
       res = await req
         .get('/languages')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${token}:secret`);
     } while (res.status === 202);
 

--- a/tests/routes/purge.spec.js
+++ b/tests/routes/purge.spec.js
@@ -40,11 +40,13 @@ describe('Purge as user', () => {
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.be.greaterThan(0);
     expect(await cache.getContent(cacheKey)).to.deep.equal({
       data: null,
     });
@@ -57,11 +59,13 @@ describe('Purge as user', () => {
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.be.greaterThan(0);
     expect(await cache.getContent(cacheKey)).to.deep.equal({
       data: null,
     });
@@ -74,11 +78,13 @@ describe('Purge as user', () => {
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 0,
+      },
     });
-    expect(res.body.count).to.equal(0);
   });
 
   it('should validate token', async () => {
@@ -115,11 +121,13 @@ describe('Purge as Transifex', () => {
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.be.greaterThan(0);
     expect(await cache.getContent(cacheKey)).to.deep.equal({
       data: null,
     });
@@ -133,11 +141,13 @@ describe('Purge as Transifex', () => {
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 1,
+      },
     });
-    expect(res.body.count).to.be.greaterThan(0);
     expect(await cache.getContent(cacheKey)).to.deep.equal({
       data: null,
     });
@@ -151,11 +161,13 @@ describe('Purge as Transifex', () => {
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
     expect(res.status).to.equal(200);
-    expect(res.body).to.deep.contain({
-      status: 'success',
-      token,
+    expect(res.body).to.deep.equal({
+      data: {
+        status: 'success',
+        token,
+        count: 0,
+      },
     });
-    expect(res.body.count).to.equal(0);
   });
 
   it('should validate token', async () => {

--- a/tests/routes/purge.spec.js
+++ b/tests/routes/purge.spec.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const request = require('supertest');
+const nock = require('nock');
 const md5 = require('../../src/helpers/md5');
 const cache = require('../../src/services/cache');
 const registry = require('../../src/services/registry');
@@ -27,6 +28,7 @@ describe('Purge as user', () => {
   });
 
   afterEach(async () => {
+    nock.cleanAll();
     await registry.del(`auth:${token}`);
     await resetRegistry();
   });
@@ -34,6 +36,7 @@ describe('Purge as user', () => {
   it('should purge all languages', async () => {
     const res = await req
       .post('/purge')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
@@ -50,6 +53,7 @@ describe('Purge as user', () => {
   it('should purge specific languages', async () => {
     const res = await req
       .post('/purge/en')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
@@ -66,6 +70,7 @@ describe('Purge as user', () => {
   it('should not purge non-existing language', async () => {
     const res = await req
       .post('/purge/abcd')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}:secret`);
 
     expect(res.status).to.equal(200);
@@ -80,6 +85,7 @@ describe('Purge as user', () => {
     await registry.del(`auth:${token}`);
     const res = await req
       .post('/purge')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}_invalid:secret`);
 
     expect(res.status).to.equal(403);
@@ -96,6 +102,7 @@ describe('Purge as Transifex', () => {
   });
 
   afterEach(async () => {
+    nock.cleanAll();
     await registry.del(`auth:${token}`);
     await resetRegistry();
   });
@@ -103,6 +110,7 @@ describe('Purge as Transifex', () => {
   it('should purge all languages', async () => {
     const res = await req
       .post('/purge')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
@@ -120,6 +128,7 @@ describe('Purge as Transifex', () => {
   it('should purge specific languages', async () => {
     const res = await req
       .post('/purge/en')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
@@ -137,6 +146,7 @@ describe('Purge as Transifex', () => {
   it('should not purge non-existing language', async () => {
     const res = await req
       .post('/purge/abcd')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'txsecret');
 
@@ -152,6 +162,7 @@ describe('Purge as Transifex', () => {
     await registry.del(`auth:${token}`);
     const res = await req
       .post('/purge')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${token}`)
       .set('X-Transifex-Trust-Secret', 'invalid');
 

--- a/tests/services/cache/route.spec.js
+++ b/tests/services/cache/route.spec.js
@@ -34,6 +34,7 @@ describe('Content cache', () => {
     do {
       res = await req
         .get('/content/en')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${cachedToken}:secret`);
     } while (res.status === 202);
 
@@ -51,6 +52,7 @@ describe('Content cache', () => {
     do {
       res = await req
         .get('/content/en')
+        .set('Accept-version', 'v2')
         .set('Authorization', `Bearer ${uncachedToken}:secret`);
     } while (res.status === 202);
 
@@ -63,6 +65,7 @@ describe('Content cache', () => {
     // cached data
     const resCached = await req
       .get('/content/en')
+      .set('Accept-version', 'v2')
       .set('Authorization', `Bearer ${uncachedToken}:secret`);
 
     expect(resCached.status).to.equal(200);

--- a/tests/services/syncer/strategies/transifex/data.spec.js
+++ b/tests/services/syncer/strategies/transifex/data.spec.js
@@ -39,10 +39,6 @@ const urls = {
 };
 
 describe('Get token information', () => {
-  beforeEach(async () => {
-    nock.cleanAll();
-  });
-
   afterEach(async () => {
     nock.cleanAll();
   });
@@ -191,8 +187,8 @@ describe('Get token information', () => {
 
 describe('Get languages', () => {
   beforeEach(async () => {
-    nock.cleanAll();
     nock(urls.api)
+      .persist()
       .get(urls.organizations)
       .reply(200, JSON.stringify({
         data: [{
@@ -203,6 +199,7 @@ describe('Get languages', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.projects)
       .reply(200, JSON.stringify({
         data: [{
@@ -220,6 +217,7 @@ describe('Get languages', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.resources)
       .reply(200, JSON.stringify({
         data: [{
@@ -298,8 +296,8 @@ describe('Get languages', () => {
 
 describe('Get Project Language Translations', () => {
   beforeEach(async () => {
-    nock.cleanAll();
     nock(urls.api)
+      .persist()
       .get(urls.organizations)
       .reply(200, JSON.stringify({
         data: [{
@@ -310,6 +308,7 @@ describe('Get Project Language Translations', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.projects)
       .reply(200, JSON.stringify({
         data: [{
@@ -327,6 +326,7 @@ describe('Get Project Language Translations', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.resources)
       .reply(200, JSON.stringify({
         data: [{
@@ -379,8 +379,8 @@ describe('Get Project Language Translations', () => {
 
 describe('Push source Content', () => {
   beforeEach(async () => {
-    nock.cleanAll();
     nock(urls.api)
+      .persist()
       .get(urls.organizations)
       .reply(200, JSON.stringify({
         data: [{
@@ -391,6 +391,7 @@ describe('Push source Content', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.projects)
       .reply(200, JSON.stringify({
         data: [{
@@ -408,6 +409,7 @@ describe('Push source Content', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.resources)
       .reply(200, JSON.stringify({
         data: [{
@@ -719,8 +721,8 @@ describe('Push source Content', () => {
 
 describe('Push source Content (per string key strategy)', () => {
   beforeEach(async () => {
-    nock.cleanAll();
     nock(urls.api)
+      .persist()
       .get(urls.organizations)
       .reply(200, JSON.stringify({
         data: [{
@@ -731,6 +733,7 @@ describe('Push source Content (per string key strategy)', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.projects)
       .reply(200, JSON.stringify({
         data: [{
@@ -748,6 +751,7 @@ describe('Push source Content (per string key strategy)', () => {
       }));
 
     nock(urls.api)
+      .persist()
       .get(urls.resources)
       .reply(200, JSON.stringify({
         data: [{
@@ -798,10 +802,6 @@ describe('Push source Content (per string key strategy)', () => {
 });
 
 describe('Verify credentials', () => {
-  beforeEach(async () => {
-    nock.cleanAll();
-  });
-
   afterEach(async () => {
     nock.cleanAll();
   });


### PR DESCRIPTION
Introduces async source content uploads.

To ensure compatibility with existing SDKs, the `Accept-version` header is introduced and the API is officially migrated to `v2`, with the old version entering a deprecation mode, to be totally removed in `1.0.0` release of the service.

Changes:
- Enable API versioning via `Accept-version` header
- Update `/health` endpoint response with more info on workers
- Update `POST /content` response
- Add `GET /jobs/content/id` endpoint for polling workers
- Update `/invalidate` and `/purge` responses
- Bump packages