### PR TITLE
Add custom prometheus metrics for worker tasks

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -3,8 +3,6 @@ const morgan = require('morgan');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const compression = require('compression');
-const _ = require('lodash');
-const queue = require('./queue');
 const config = require('./config');
 const { version } = require('../package.json');
 const sentry = require('./sentry');
@@ -52,11 +50,9 @@ module.exports = () => {
 
   // for nagios health check
   app.get('/health', async (req, res) => {
-    const counts = await queue.countJobs();
     res.json({
       version,
       status: 'ok',
-      jobs: _.pick(counts, 'waiting', 'active', 'delayed'),
     });
   });
 


### PR DESCRIPTION
Add the following Prometheus custom metrics:

- jobs_waiting
- jobs_active
- jobs_delayed

which can be used by any external system (ex. Kubernetes) for scaling purposes.