### PR TITLE
Add HTTP 409 response on POST /content

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,18 @@ Response body:
   }
 }
 
+Response status: 409
+Response body:
+{
+  status: 409,
+  message: 'Another content upload is already in progress',
+}
+
 Response status: 429
 Response body:
 {
   status: 429,
-  message: 'Another content upload is already in progress',
+  message: 'Too many requests, please try again later.',
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "transifex-delivery",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transifex-delivery",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Transifex Content Delivery Service",
   "keywords": [
     "transifex",

--- a/src/queue/index.js
+++ b/src/queue/index.js
@@ -44,6 +44,16 @@ async function addJob(jobId, payload) {
 }
 
 /**
+ * Check if job exists.
+ *
+ * @param {String} jobId
+ */
+async function hasJob(jobId) {
+  const job = await queue.getJob(jobId);
+  return !!job;
+}
+
+/**
  * Return the number of jobs in the queue.
  *
  * @returns {Object}
@@ -56,5 +66,6 @@ async function countJobs() {
 module.exports = {
   initialize,
   addJob,
+  hasJob,
   countJobs,
 };


### PR DESCRIPTION
Fixes unused Redis job-ID keys being created that would never resolve when pushing the same content.