### PR TITLE
Gracefully abort failed jobs

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -34,7 +34,7 @@ settings:
   pull_success_cache_min: 10080
 
   # Minutes to cache failed pulls in the registry
-  pull_error_cache_min: 15
+  pull_error_cache_min: 5
 
   # Minutes to cache job status in registry
   job_status_cache_min: 480

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "transifex-delivery",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "transifex-delivery",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-cloud/storage": "^5.19.4",
+        "@google-cloud/storage": "^5.20.5",
         "@sentry/node": "^6.19.7",
-        "aws-sdk": "^2.1135.0",
+        "aws-sdk": "^2.1141.0",
         "axios": "^0.27.2",
         "axios-retry": "^3.2.5",
         "body-parser": "^1.20.0",
@@ -30,7 +30,7 @@
         "morgan": "^1.10.0",
         "nconf": "^0.12.0",
         "nconf-yaml": "^1.0.2",
-        "newrelic": "^8.11.1",
+        "newrelic": "^8.11.2",
         "node-cache": "^5.1.2",
         "prom-client": "^14.0.1",
         "uuid": "^8.3.2",
@@ -652,9 +652,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "5.19.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.19.4.tgz",
-      "integrity": "sha512-Jz7ugcPHhsEmMVvIxM9uoBsdEbKIYwDkh3u07tifsIymEWs47F4/D6+/Tv/W7kLhznqjyOjVJ/0frtBeIC0lJA==",
+      "version": "5.20.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.20.5.tgz",
+      "integrity": "sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==",
       "dependencies": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^2.0.0",
@@ -664,12 +664,10 @@
         "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
         "configstore": "^5.0.0",
-        "date-and-time": "^2.0.0",
         "duplexify": "^4.0.0",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "get-stream": "^6.0.0",
         "google-auth-library": "^7.14.1",
         "hash-stream-validation": "^0.2.2",
         "mime": "^3.0.0",
@@ -677,24 +675,13 @@
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
         "retry-request": "^4.2.2",
-        "snakeize": "^0.1.0",
         "stream-events": "^1.0.4",
         "teeny-request": "^7.1.3",
+        "uuid": "^8.0.0",
         "xdg-basedir": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/mime": {
@@ -975,17 +962,6 @@
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"
-      }
-    },
-    "node_modules/@newrelic/winston-enricher": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-3.1.1.tgz",
-      "integrity": "sha512-ioLw2H10CTPknd9kUvAAjMeg3n32WsEfW/N+gTGEOs1OhK9wB1ZWOYOEj54Zkas/ATwQsl4V/m6AAcJp891Pww==",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "newrelic": ">=6.2.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1513,9 +1489,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/aws-sdk": {
-      "version": "2.1135.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1135.0.tgz",
-      "integrity": "sha512-bl9n4QgrEh52hmQ+Jo76BgJXM/p+PwfVZvImEQHFeel/33H/PDLcTJquEw5bzxM1HRNI24iH+FNPwyWLMrttTw==",
+      "version": "2.1141.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1141.0.tgz",
+      "integrity": "sha512-AIZhWB51UEMcU7zKOrbCzCnHtXJTjmO+3PDIjwc5+8tT623Ud/vcrvSlxmqNxrgSnlXThLrxH9fTw/n/sxiXxg==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -2316,11 +2292,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/date-and-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.0.tgz",
-      "integrity": "sha512-HJSzj25iPm8E01nt+rSmCIlwjsmjvKfUivG/kXBglpymcHF1FolWAqWwTEV4FvN1Lx5UjPf0J1W4H8yQsVBfFg=="
     },
     "node_modules/dayjs": {
       "version": "1.11.2",
@@ -5406,16 +5377,15 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.11.1.tgz",
-      "integrity": "sha512-AWXYdOHuzT58k4/q5QdWPzaLVz4IdEjjJ78aGnU4w3PV4uV909HxiszGd/t23BWrIVlDQrHVrsY+k5VOTzNr0A==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.11.2.tgz",
+      "integrity": "sha512-8OCeMa2F7IIjYZsP+vnzQA4QIPenNmBPqBW934t34P8emllz90nU+0S843L44wWY2P5zt5EKDypIzuXyEmchEA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.9",
         "@newrelic/aws-sdk": "^4.1.1",
         "@newrelic/koa": "^6.1.1",
         "@newrelic/superagent": "^5.1.0",
-        "@newrelic/winston-enricher": "^3.1.1",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "async": "^3.2.3",
         "concat-stream": "^2.0.0",
@@ -6901,11 +6871,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/snakeize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -8407,9 +8372,9 @@
       "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
     },
     "@google-cloud/storage": {
-      "version": "5.19.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.19.4.tgz",
-      "integrity": "sha512-Jz7ugcPHhsEmMVvIxM9uoBsdEbKIYwDkh3u07tifsIymEWs47F4/D6+/Tv/W7kLhznqjyOjVJ/0frtBeIC0lJA==",
+      "version": "5.20.5",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.20.5.tgz",
+      "integrity": "sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==",
       "requires": {
         "@google-cloud/paginator": "^3.0.7",
         "@google-cloud/projectify": "^2.0.0",
@@ -8419,12 +8384,10 @@
         "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
         "configstore": "^5.0.0",
-        "date-and-time": "^2.0.0",
         "duplexify": "^4.0.0",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "get-stream": "^6.0.0",
         "google-auth-library": "^7.14.1",
         "hash-stream-validation": "^0.2.2",
         "mime": "^3.0.0",
@@ -8432,17 +8395,12 @@
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
         "retry-request": "^4.2.2",
-        "snakeize": "^0.1.0",
         "stream-events": "^1.0.4",
         "teeny-request": "^7.1.3",
+        "uuid": "^8.0.0",
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-        },
         "mime": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -8642,12 +8600,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-5.1.1.tgz",
       "integrity": "sha512-Bp2QtknriKHLKSfrBRyg4PjGJ8CCSkxYfZEDppOWmrGukJAP/9Vvr+ya0Mmj7SU8eIMMhaTvAnjvb2mVmX8wBw==",
-      "requires": {}
-    },
-    "@newrelic/winston-enricher": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-3.1.1.tgz",
-      "integrity": "sha512-ioLw2H10CTPknd9kUvAAjMeg3n32WsEfW/N+gTGEOs1OhK9wB1ZWOYOEj54Zkas/ATwQsl4V/m6AAcJp891Pww==",
       "requires": {}
     },
     "@protobufjs/aspromise": {
@@ -9079,9 +9031,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.1135.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1135.0.tgz",
-      "integrity": "sha512-bl9n4QgrEh52hmQ+Jo76BgJXM/p+PwfVZvImEQHFeel/33H/PDLcTJquEw5bzxM1HRNI24iH+FNPwyWLMrttTw==",
+      "version": "2.1141.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1141.0.tgz",
+      "integrity": "sha512-AIZhWB51UEMcU7zKOrbCzCnHtXJTjmO+3PDIjwc5+8tT623Ud/vcrvSlxmqNxrgSnlXThLrxH9fTw/n/sxiXxg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -9702,11 +9654,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
-    },
-    "date-and-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.0.tgz",
-      "integrity": "sha512-HJSzj25iPm8E01nt+rSmCIlwjsmjvKfUivG/kXBglpymcHF1FolWAqWwTEV4FvN1Lx5UjPf0J1W4H8yQsVBfFg=="
     },
     "dayjs": {
       "version": "1.11.2",
@@ -12022,9 +11969,9 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "newrelic": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.11.1.tgz",
-      "integrity": "sha512-AWXYdOHuzT58k4/q5QdWPzaLVz4IdEjjJ78aGnU4w3PV4uV909HxiszGd/t23BWrIVlDQrHVrsY+k5VOTzNr0A==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.11.2.tgz",
+      "integrity": "sha512-8OCeMa2F7IIjYZsP+vnzQA4QIPenNmBPqBW934t34P8emllz90nU+0S843L44wWY2P5zt5EKDypIzuXyEmchEA==",
       "requires": {
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.9",
@@ -12032,7 +11979,6 @@
         "@newrelic/koa": "^6.1.1",
         "@newrelic/native-metrics": "^8.0.0",
         "@newrelic/superagent": "^5.1.0",
-        "@newrelic/winston-enricher": "^3.1.1",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "async": "^3.2.3",
         "concat-stream": "^2.0.0",
@@ -13162,11 +13108,6 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
-    },
-    "snakeize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transifex-delivery",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Transifex Content Delivery Service",
   "keywords": [
     "transifex",
@@ -28,9 +28,9 @@
   "homepage": "https://github.com/transifex/transifex-delivery",
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/storage": "^5.19.4",
+    "@google-cloud/storage": "^5.20.5",
     "@sentry/node": "^6.19.7",
-    "aws-sdk": "^2.1135.0",
+    "aws-sdk": "^2.1141.0",
     "axios": "^0.27.2",
     "axios-retry": "^3.2.5",
     "body-parser": "^1.20.0",
@@ -49,7 +49,7 @@
     "morgan": "^1.10.0",
     "nconf": "^0.12.0",
     "nconf-yaml": "^1.0.2",
-    "newrelic": "^8.11.1",
+    "newrelic": "^8.11.2",
     "node-cache": "^5.1.2",
     "prom-client": "^14.0.1",
     "uuid": "^8.3.2",

--- a/src/queue/index.js
+++ b/src/queue/index.js
@@ -39,7 +39,6 @@ async function addJob(jobId, payload) {
     jobId,
     removeOnComplete: true,
     removeOnFail: true,
-    attempts: 3,
   });
 }
 


### PR DESCRIPTION
When Transifex is down (e.g. during maintenance windows), the APIv3 endpoints return `503` status code.

This case was not properly covered by the workers and the failed jobs (e.g. pull or push content) could not gracefully fail, leaving the job status in a zombie state.

As a side effect, hitting `/languages` or `/content` endpoints could end-up in an infinite `202` response (job in progress, try again later).

With this fix, a failed job will properly set it's status to `fail`, so that CDS endpoints status code could eventually stop looping forever.