### PR TITLE
Add support for dry-run when pushing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ If `override_tags: true` in `meta` object, then replace the existing string tags
 
 If `override_tags: false` in `meta` object (the default), then append tags from source content to tags of existing strings instead of overwriting them.
 
+**Dry run**
+
+If `dry_run: true` in `meta` object, then emulate a content push, without doing actual changes.
+
 ```
 POST /content
 
@@ -210,7 +214,8 @@ Request body:
   },
   meta: {
     purge: <boolean>,
-    override_tags: <boolean>
+    override_tags: <boolean>,
+    dry_run: <boolean>
   }
 }
 

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -10,6 +10,7 @@ const PUSH_SOURCE_CONTENT_SCHEMA = joi.object().keys({
   meta: joi.object().keys({
     purge: joi.boolean(),
     override_tags: joi.boolean(),
+    dry_run: joi.boolean(),
   }),
 });
 

--- a/src/services/syncer/data.js
+++ b/src/services/syncer/data.js
@@ -91,6 +91,8 @@ async function getProjectLanguageTranslations(options, langCode) {
  *   },
  *   meta: {
  *     purge: <boolean>,
+ *     override_tags: <boolean>,
+ *     dry_run: <boolean>
  *   },
  * }
  *

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -585,26 +585,32 @@ async function pushSourceContent(token, options) {
     }
   }
 
-  // Send for Delete and return errors
-  const deletedStrings = await deleteSourceContent(token, {
-    payload: deletePayloads,
-  });
-  deleted += deletedStrings.count;
-  errors = _.concat(errors, deletedStrings.errors);
+  if (meta.dry_run) {
+    deleted += deletePayloads.length;
+    created += createPayloads.length;
+    updated += updatePayloads.length;
+  } else {
+    // Send for Delete and return errors
+    const deletedStrings = await deleteSourceContent(token, {
+      payload: deletePayloads,
+    });
+    deleted += deletedStrings.count;
+    errors = _.concat(errors, deletedStrings.errors);
 
-  // Send for post and return created and errors
-  const postedStrings = await postSourceContent(token, {
-    payload: createPayloads,
-  });
-  created += postedStrings.createdStrings.length;
-  errors = _.concat(errors, postedStrings.errors);
+    // Send for post and return created and errors
+    const postedStrings = await postSourceContent(token, {
+      payload: createPayloads,
+    });
+    created += postedStrings.createdStrings.length;
+    errors = _.concat(errors, postedStrings.errors);
 
-  // Send for Patch and return updated and errors
-  const patchedStrings = await patchSourceContent(token, {
-    payload: updatePayloads,
-  });
-  updated += patchedStrings.updatedStrings.length;
-  errors = _.concat(errors, patchedStrings.errors);
+    // Send for Patch and return updated and errors
+    const patchedStrings = await patchSourceContent(token, {
+      payload: updatePayloads,
+    });
+    updated += patchedStrings.updatedStrings.length;
+    errors = _.concat(errors, patchedStrings.errors);
+  }
 
   return {
     created,

--- a/tests/services/syncer/strategies/transifex/data.spec.js
+++ b/tests/services/syncer/strategies/transifex/data.spec.js
@@ -461,6 +461,29 @@ describe('Push source Content', () => {
     });
   });
 
+  it('should push new strings with dry run', async () => {
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, { data: [], links: {} });
+    nock(urls.api)
+      .get(urls.source_strings_revisions)
+      .reply(200, { data: [], links: {} });
+
+    const data = dataHelper.getPushSourceContent();
+    const result = await transifexData.pushSourceContent(options, data, {
+      dry_run: true,
+    });
+
+    expect(result).to.eql({
+      created: 2,
+      updated: 0,
+      skipped: 0,
+      deleted: 0,
+      failed: 0,
+      errors: [],
+    });
+  });
+
   it('should return correct report on errors', async () => {
     nock(urls.api)
       .get(urls.source_strings)


### PR DESCRIPTION
Add support for emulating content push (dry run), so that SDKs can check which strings will be created, updated, deleted or skipped, in relation to the actual content in Transifex.