### PR TITLE
Add filter[status] support to get content endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Get localized content for a specific language code.
 ```
 GET /content/<lang-code>
 GET /content/<lang-code>?filter[tags]=tag1,tag2
+GET /content/<lang-code>?filter[status]=translated|reviewed|proofread|finalized
 
 Authorization: Bearer <project-token>
 Content-Type: application/json; charset=utf-8

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -30,16 +30,24 @@ async function getContent(req, res) {
   let key = `${req.token.project_token}:${req.params.lang_code}:content`;
 
   // parse tags filter
-  let filter = {};
+  const filter = {};
   const tags = cleanTags(_.get(req.query, 'filter.tags'));
   if (tags) {
     // update filter
-    filter = {
-      tags,
-    };
+    filter.tags = tags;
     // add tags to key
     key = `${key}[${tags}]`;
   }
+
+  // parse status filter
+  const filterStatus = _.get(req.query, 'filter.status');
+  if (filterStatus) {
+    // update filter
+    filter.status = filterStatus;
+    // add status to key
+    key = `${key}{${filterStatus}}`;
+  }
+
   const sentContent = await routerCacheHelper(
     req,
     res,

--- a/src/routes/invalidate.js
+++ b/src/routes/invalidate.js
@@ -37,6 +37,15 @@ router.post(
         } catch (e) {
           // no-op
         }
+        // optionally match {status} filter
+        try {
+          let status = matches[1];
+          status = status.match(/\{(.*)\}/);
+          // eslint-disable-next-line prefer-destructuring
+          filter.status = status[1];
+        } catch (e) {
+          // no-op
+        }
         queue.addJob(jobKey, {
           type: 'syncer:pull',
           key: jobKey,
@@ -105,6 +114,15 @@ router.post(
               tags = tags.match(/\[(.*)\]/);
               // eslint-disable-next-line prefer-destructuring
               filter.tags = tags[1];
+            } catch (e) {
+              // no-op
+            }
+            // optionally match {status} filter
+            try {
+              let status = matches[2];
+              status = status.match(/\{(.*)\}/);
+              // eslint-disable-next-line prefer-destructuring
+              filter.status = status[1];
             } catch (e) {
               // no-op
             }

--- a/src/services/syncer/data.js
+++ b/src/services/syncer/data.js
@@ -49,6 +49,7 @@ async function getLanguages(options) {
  * @param {Object} options.token
  * @param {Object} options.filter (optional)
  * @param {String} options.filter.tags (optional)
+ * @param {String} options.filter.status (optional)
  * @param {String} lang_code The language code of the translations
  * @returns {Object} An object with the available strings and translations
  * Important: Keep in mind that the `data` key is an object

--- a/src/services/syncer/strategies/transifex/data.js
+++ b/src/services/syncer/strategies/transifex/data.js
@@ -121,6 +121,7 @@ async function getProjectLanguageTranslations(options, langCode) {
         project_slug: info.token.project_slug,
         resource_slug: info.token.resource_slug,
         filter_tags: _.get(options, 'filter.tags'),
+        filter_status: _.get(options, 'filter.status'),
       });
       return {
         data: Object.fromEntries(parseProjectLanguageSources(result)),
@@ -133,6 +134,7 @@ async function getProjectLanguageTranslations(options, langCode) {
       resource_slug: info.token.resource_slug,
       lang_code: langCode,
       filter_tags: _.get(options, 'filter.tags'),
+      filter_status: _.get(options, 'filter.status'),
     });
     return result;
   } catch (e) {

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -115,24 +115,22 @@ async function getTargetLanguages(token, options) {
 async function getProjectLanguageTranslations(token, options) {
   let concatenatedData = new Map();
 
-  let urlKey = 'GET_RESOURCE_TRANSLATIONS';
-  let urlParams = {
+  const urlParams = {
     ORGANIZATION_SLUG: `o:${options.organization_slug}`,
     PROJECT_SLUG: `p:${options.project_slug}`,
     RESOURCE_SLUG: `r:${options.resource_slug}`,
     LANGUAGE_CODE: `l:${options.lang_code}`,
   };
 
-  // add filter
+  // add filters
   if (options.filter_tags) {
-    urlKey = 'GET_RESOURCE_TRANSLATIONS_FILTER_TAGS';
-    urlParams = {
-      ...urlParams,
-      FILTER_TAGS: options.filter_tags,
-    };
+    urlParams.FILTER_TAGS = options.filter_tags;
+  }
+  if (options.filter_status) {
+    urlParams.FILTER_STATUS = options.filter_status;
   }
 
-  let url = apiUrls.getUrl(urlKey, urlParams);
+  let url = apiUrls.getUrl('GET_RESOURCE_TRANSLATIONS', urlParams);
   let result = null;
   while (url) {
     logger.info(`GET ${url}`);
@@ -162,8 +160,7 @@ async function getProjectLanguageTranslations(token, options) {
 async function getSourceContentMap(token, options) {
   let concatenatedData = new Map();
 
-  let urlKey = 'GET_RESOURCE_STRINGS';
-  let urlParams = {
+  const urlParams = {
     ORGANIZATION_SLUG: `o:${options.organization_slug}`,
     PROJECT_SLUG: `p:${options.project_slug}`,
     RESOURCE_SLUG: `r:${options.resource_slug}`,
@@ -171,14 +168,10 @@ async function getSourceContentMap(token, options) {
 
   // add filter
   if (options.filter_tags) {
-    urlKey = 'GET_RESOURCE_STRINGS_FILTER_TAGS';
-    urlParams = {
-      ...urlParams,
-      FILTER_TAGS: options.filter_tags,
-    };
+    urlParams.FILTER_TAGS = options.filter_tags;
   }
 
-  let url = apiUrls.getUrl(urlKey, urlParams);
+  let url = apiUrls.getUrl('GET_RESOURCE_STRINGS', urlParams);
   const headers = apiUrls.getHeaders(token);
 
   let result = null;
@@ -196,20 +189,15 @@ async function getSourceContentMap(token, options) {
 
 async function getRevisions(token, options) {
   const concatenatedData = {};
-  let urlKey = 'GET_RESOURCE_STRINGS_REVISIONS';
-  let urlParams = {
+  const urlParams = {
     ORGANIZATION_SLUG: `o:${options.organization_slug}`,
     PROJECT_SLUG: `p:${options.project_slug}`,
     RESOURCE_SLUG: `r:${options.resource_slug}`,
   };
   if (options.filter_tags) {
-    urlKey = 'GET_RESOURCE_STRINGS_REVISIONS_FILTER_TAGS';
-    urlParams = {
-      ...urlParams,
-      FILTER_TAGS: options.filter_tags,
-    };
+    urlParams.FILTER_TAGS = options.filter_tags;
   }
-  let url = apiUrls.getUrl(urlKey, urlParams);
+  let url = apiUrls.getUrl('GET_RESOURCE_STRINGS_REVISIONS', urlParams);
   const headers = apiUrls.getHeaders(token);
   let result = null;
   while (url) {

--- a/src/services/syncer/strategies/transifex/utils/api_urls.js
+++ b/src/services/syncer/strategies/transifex/utils/api_urls.js
@@ -9,7 +9,6 @@ const TRANSIFEX_API_KEYS = {
   PROJECT_SLUG: 'p:project_slug',
   LANGUAGE_CODE: 'l:language_code',
   RESOURCE_SLUG: 'r:resource_slug',
-  FILTER_TAGS: 'f:tags',
   FILTER_KEY: 'f:key',
 };
 
@@ -19,7 +18,6 @@ const ENTITY_IDS = {
   PROJECT: 'o:organization_slug:p:project_slug',
   RESOURCE: 'o:organization_slug:p:project_slug:r:resource_slug',
   LANGUAGE: 'l:language_code',
-  TAGS: 'f:tags',
   KEY: 'f:key',
 };
 
@@ -30,11 +28,6 @@ const TRANSIFEX_API_URLS = {
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
     + `filter[language]=${ENTITY_IDS.LANGUAGE}&include=resource_string&`
     + `limit=${PAGE_LIMIT}`,
-  GET_RESOURCE_TRANSLATIONS_FILTER_TAGS: '/resource_translations?'
-    + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
-    + `filter[language]=${ENTITY_IDS.LANGUAGE}&include=resource_string&`
-    + `filter[resource_string][tags][all]=${ENTITY_IDS.TAGS}&`
-    + `limit=${PAGE_LIMIT}`,
   RESOURCE_STRINGS: '/resource_strings',
   GET_RESOURCE_STRINGS: '/resource_strings?'
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
@@ -43,19 +36,11 @@ const TRANSIFEX_API_URLS = {
     + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
     + `filter[key]=${ENTITY_IDS.KEY}&`
     + `limit=${PAGE_LIMIT}`,
-  GET_RESOURCE_STRINGS_FILTER_TAGS: '/resource_strings?'
-    + `filter[resource]=${ENTITY_IDS.RESOURCE}&`
-    + `filter[tags][all]=${ENTITY_IDS.TAGS}&`
-    + `limit=${PAGE_LIMIT}`,
   ORGANIZATIONS: '/organizations',
   PROJECTS: `/projects?filter[organization]=${ENTITY_IDS.ORGANIZATION}`,
   RESOURCES: `/resources?filter[project]=${ENTITY_IDS.PROJECT}`,
   GET_RESOURCE_STRINGS_REVISIONS: '/resource_strings_revisions?'
     + `filter[resource_string][resource]=${ENTITY_IDS.RESOURCE}&`
-    + `limit=${PAGE_LIMIT}`,
-  GET_RESOURCE_STRINGS_REVISIONS_FILTER_TAGS: '/resource_strings_revisions?'
-    + `filter[resource_string][resource]=${ENTITY_IDS.RESOURCE}&`
-    + `filter[resource_string][tags][all]=${ENTITY_IDS.TAGS}&`
     + `limit=${PAGE_LIMIT}`,
   GET_RESOURCE_STRINGS_REVISIONS_FILTER_KEY: '/resource_strings_revisions?'
     + `filter[resource_string][resource]=${ENTITY_IDS.RESOURCE}&`
@@ -66,11 +51,41 @@ const TRANSIFEX_API_URLS = {
 function getUrl(url, parameters) {
   let result = `${TRANSIFEX_API_HOST}${TRANSIFEX_API_URLS[url]}`;
 
-  for (const item in parameters) {
-    if (Object.prototype.hasOwnProperty.call(parameters, item)) {
-      result = result.replace(TRANSIFEX_API_KEYS[item], parameters[item]);
+  if (parameters) {
+    for (const item in parameters) {
+      if (Object.prototype.hasOwnProperty.call(parameters, item)) {
+        result = result.replace(TRANSIFEX_API_KEYS[item], parameters[item]);
+      }
+    }
+
+    // add filters on URLs that support it
+    if (parameters.FILTER_TAGS) {
+      switch (url) {
+        case 'GET_RESOURCE_TRANSLATIONS':
+        case 'GET_RESOURCE_STRINGS_REVISIONS':
+          result = `${result}&filter[resource_string][tags][all]=${parameters.FILTER_TAGS}`;
+          break;
+        case 'GET_RESOURCE_STRINGS':
+          result = `${result}&filter[tags][all]=${parameters.FILTER_TAGS}`;
+          break;
+        default:
+          break;
+      }
+    }
+    if (parameters.FILTER_STATUS && url === 'GET_RESOURCE_TRANSLATIONS') {
+      switch (parameters.FILTER_STATUS) {
+        case 'translated':
+        case 'reviewed':
+        case 'proofread':
+        case 'finalized':
+          result = `${result}&filter[${parameters.FILTER_STATUS}]=true`;
+          break;
+        default:
+          break;
+      }
     }
   }
+
   return result;
 }
 


### PR DESCRIPTION
Add support for filtering content to be fetched by translation status:
```
GET /content/<lang-code>?filter[status]=translated|reviewed|proofread|finalized
```
Backend implementation works in par with [Transifex APIv3](https://developers.transifex.com/reference/get_resource-translations).
