### PR TITLE
TX-14726 - changes to zh-Hant and zh-Hans text in language picker

### DIFF
--- a/src/helpers/languages.js
+++ b/src/helpers/languages.js
@@ -2337,13 +2337,13 @@ const LANGUAGES = {
   'zh-Hans': {
     code: 'zh-Hans',
     name: 'Chinese Simplified',
-    localized_name: '中文 (简)',
+    localized_name: '简体中文',
     rtl: false,
   },
   'zh-Hant': {
     code: 'zh-Hant',
     name: 'Chinese Traditional',
-    localized_name: '中文 (傳統)',
+    localized_name: '繁體中文',
     rtl: false,
   },
   tzl: {


### PR DESCRIPTION
I updated the text displayed on the language picker for zh-Hant and zh-Hans languages. The previous translation was not natural for native language speakers. 
