### PR TITLE
Add support for appending occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ If `override_tags: true` in `meta` object, then replace the existing string tags
 
 If `override_tags: false` in `meta` object (the default), then append tags from source content to tags of existing strings instead of overwriting them.
 
+**Replace occurrences**
+
+If `override_occurrences: true` in `meta` object, then replace the existing string occurrences with the occurrences of this request.
+
+If `override_occurrences: false` in `meta` object (the default), then append occurrences from source content to occurrences of existing strings instead of overwriting them.
+
 **Keep translations**
 
 if `keep_translations: true` in `meta` object (the default), then preserve translations on source content updates.
@@ -222,6 +228,7 @@ Request body:
   "meta": {
     "purge": <boolean>,
     "override_tags": <boolean>,
+    "override_occurrences": <boolean>,
     "keep_translations": <boolean>,
     "dry_run": <boolean>
   }

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -10,6 +10,7 @@ const PUSH_SOURCE_CONTENT_SCHEMA = joi.object().keys({
   meta: joi.object().keys({
     purge: joi.boolean(),
     override_tags: joi.boolean(),
+    override_occurrences: joi.boolean(),
     keep_translations: joi.boolean(),
     dry_run: joi.boolean(),
   }),

--- a/src/services/syncer/data.js
+++ b/src/services/syncer/data.js
@@ -93,6 +93,7 @@ async function getProjectLanguageTranslations(options, langCode) {
  *   meta: {
  *     purge: <boolean>,
  *     override_tags: <boolean>,
+ *     override_occurrences: <boolean>,
  *     keep_translations: <boolean>,
  *     dry_run: <boolean>
  *   },

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -579,7 +579,18 @@ async function pushSourceContent(token, options) {
         common.add(key);
         // append tags
         if (meta.override_tags !== true) {
-          attributes.tags = _.uniq(_.union(existingString.attributes.tags, attributes.tags));
+          attributes.tags = _.compact(_.uniq(
+            _.union(existingString.attributes.tags, attributes.tags),
+          ));
+        }
+        // append occurences
+        if (meta.override_occurrences !== true) {
+          attributes.occurrences = _.compact(_.uniq(
+            _.union(
+              (existingString.attributes.occurrences || '').split(','),
+              (attributes.occurrences || '').split(','),
+            ),
+          )).join(',');
         }
       }
 

--- a/src/services/syncer/strategies/transifex/utils/api_payloads.js
+++ b/src/services/syncer/strategies/transifex/utils/api_payloads.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const PATCH_ATTRIBUTES = ['character_limit', 'tags', 'developer_comment'];
+const PATCH_ATTRIBUTES = ['character_limit', 'tags', 'developer_comment', 'occurrences'];
 
 function getPushStringPayload(resourceId, attributes) {
   return {


### PR DESCRIPTION
By default merge occurrences of a string, similar to the way `tags` work.

If `override_occurrences` is set in the `POST /content` metadata, then override target occurrences.