### PR TITLE
Disable path and merge status codes in prom metrics

### DIFF
--- a/src/middlewares/metrics.js
+++ b/src/middlewares/metrics.js
@@ -6,7 +6,7 @@ const queue = require('../queue');
 
 const isEnabled = config.get('metrics:enabled');
 const prometheusBundle = isEnabled ? promBundle({
-  includePath: true,
+  includePath: false,
   includeMethod: true,
   autoregister: false, // Do not register the metrics endpoint
   promClient: {


### PR DESCRIPTION
## Tested on tx-cds BETA

/metrics on web pod
```
# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{application="transifex-delivery",environment="beta"} 13.413768000000006

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{application="transifex-delivery",environment="beta"} 3.098908999999999

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{application="transifex-delivery",environment="beta"} 16.51267699999999

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{application="transifex-delivery",environment="beta"} 1694523365

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{application="transifex-delivery",environment="beta"} 75350016

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes{application="transifex-delivery",environment="beta"} 733446144

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes{application="transifex-delivery",environment="beta"} 107737088

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds{application="transifex-delivery",environment="beta"} 31

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds{application="transifex-delivery",environment="beta"} 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{application="transifex-delivery",environment="beta"} 0.001779731

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{application="transifex-delivery",environment="beta"} 0.00905216

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{application="transifex-delivery",environment="beta"} 0.018694143

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{application="transifex-delivery",environment="beta"} 0.010085210510755654

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{application="transifex-delivery",environment="beta"} 0.00028550778212085826

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{application="transifex-delivery",environment="beta"} 0.010076159

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{application="transifex-delivery",environment="beta"} 0.010084351

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{application="transifex-delivery",environment="beta"} 0.010239999

# HELP nodejs_active_resources Number of active resources that are currently keeping the event loop alive, grouped by async resource type.
# TYPE nodejs_active_resources gauge
nodejs_active_resources{type="PipeWrap",application="transifex-delivery",environment="beta"} 2
nodejs_active_resources{type="TCPSocketWrap",application="transifex-delivery",environment="beta"} 3
nodejs_active_resources{type="TCPServerWrap",application="transifex-delivery",environment="beta"} 2
nodejs_active_resources{type="Timeout",application="transifex-delivery",environment="beta"} 1
nodejs_active_resources{type="Immediate",application="transifex-delivery",environment="beta"} 1

# HELP nodejs_active_resources_total Total number of active resources.
# TYPE nodejs_active_resources_total gauge
nodejs_active_resources_total{application="transifex-delivery",environment="beta"} 9

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="Socket",application="transifex-delivery",environment="beta"} 5
nodejs_active_handles{type="Server",application="transifex-delivery",environment="beta"} 2

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{application="transifex-delivery",environment="beta"} 7

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{application="transifex-delivery",environment="beta"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{application="transifex-delivery",environment="beta"} 27095040

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{application="transifex-delivery",environment="beta"} 24683216

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{application="transifex-delivery",environment="beta"} 2378135

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_total_bytes{space="new",application="transifex-delivery",environment="beta"} 1048576
nodejs_heap_space_size_total_bytes{space="old",application="transifex-delivery",environment="beta"} 21893120
nodejs_heap_space_size_total_bytes{space="code",application="transifex-delivery",environment="beta"} 2359296
nodejs_heap_space_size_total_bytes{space="shared",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_total_bytes{space="new_large_object",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_total_bytes{space="large_object",application="transifex-delivery",environment="beta"} 1794048
nodejs_heap_space_size_total_bytes{space="code_large_object",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_total_bytes{space="shared_large_object",application="transifex-delivery",environment="beta"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_used_bytes{space="new",application="transifex-delivery",environment="beta"} 452456
nodejs_heap_space_size_used_bytes{space="old",application="transifex-delivery",environment="beta"} 20531840
nodejs_heap_space_size_used_bytes{space="code",application="transifex-delivery",environment="beta"} 1929728
nodejs_heap_space_size_used_bytes{space="shared",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_used_bytes{space="new_large_object",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_used_bytes{space="large_object",application="transifex-delivery",environment="beta"} 1773080
nodejs_heap_space_size_used_bytes{space="code_large_object",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_used_bytes{space="shared_large_object",application="transifex-delivery",environment="beta"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_available_bytes{space="new",application="transifex-delivery",environment="beta"} 578424
nodejs_heap_space_size_available_bytes{space="old",application="transifex-delivery",environment="beta"} 917256
nodejs_heap_space_size_available_bytes{space="code",application="transifex-delivery",environment="beta"} 281664
nodejs_heap_space_size_available_bytes{space="shared",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",application="transifex-delivery",environment="beta"} 1048576
nodejs_heap_space_size_available_bytes{space="large_object",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",application="transifex-delivery",environment="beta"} 0
nodejs_heap_space_size_available_bytes{space="shared_large_object",application="transifex-delivery",environment="beta"} 0

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v20.5.0",major="20",minor="5",patch="0",application="transifex-delivery",environment="beta"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",application="transifex-delivery",environment="beta"} 481
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_sum{kind="minor",application="transifex-delivery",environment="beta"} 0.2899151728749276
nodejs_gc_duration_seconds_count{kind="minor",application="transifex-delivery",environment="beta"} 491
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",application="transifex-delivery",environment="beta"} 9
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",application="transifex-delivery",environment="beta"} 11
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",application="transifex-delivery",environment="beta"} 14
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",application="transifex-delivery",environment="beta"} 14
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",application="transifex-delivery",environment="beta"} 14
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",application="transifex-delivery",environment="beta"} 14
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",application="transifex-delivery",environment="beta"} 14
nodejs_gc_duration_seconds_sum{kind="incremental",application="transifex-delivery",environment="beta"} 0.04673574393987656
nodejs_gc_duration_seconds_count{kind="incremental",application="transifex-delivery",environment="beta"} 14
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",application="transifex-delivery",environment="beta"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",application="transifex-delivery",environment="beta"} 11
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",application="transifex-delivery",environment="beta"} 12
nodejs_gc_duration_seconds_bucket{le="1",kind="major",application="transifex-delivery",environment="beta"} 12
nodejs_gc_duration_seconds_bucket{le="2",kind="major",application="transifex-delivery",environment="beta"} 12
nodejs_gc_duration_seconds_bucket{le="5",kind="major",application="transifex-delivery",environment="beta"} 12
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",application="transifex-delivery",environment="beta"} 12
nodejs_gc_duration_seconds_sum{kind="major",application="transifex-delivery",environment="beta"} 0.03844891500473022
nodejs_gc_duration_seconds_count{kind="major",application="transifex-delivery",environment="beta"} 12

# HELP http_request_duration_seconds duration histogram of http responses labeled with: status_code, method
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{le="0.003",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 620
http_request_duration_seconds_bucket{le="0.03",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625
http_request_duration_seconds_bucket{le="0.1",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625
http_request_duration_seconds_bucket{le="0.3",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625
http_request_duration_seconds_bucket{le="1.5",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625
http_request_duration_seconds_bucket{le="10",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625
http_request_duration_seconds_bucket{le="+Inf",status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625
http_request_duration_seconds_sum{status_code="200",method="GET",application="transifex-delivery",environment="beta"} 0.4402263559999995
http_request_duration_seconds_count{status_code="200",method="GET",application="transifex-delivery",environment="beta"} 625

# HELP up 1 = up, 0 = not up
# TYPE up gauge
up{application="transifex-delivery",environment="beta"} 1

# HELP tx_cds_beta_jobs_waiting Number of jobs with a waiting status
# TYPE tx_cds_beta_jobs_waiting gauge
tx_cds_beta_jobs_waiting{application="transifex-delivery",environment="beta"} 0

# HELP tx_cds_beta_jobs_active Number of jobs with an active status
# TYPE tx_cds_beta_jobs_active gauge
tx_cds_beta_jobs_active{application="transifex-delivery",environment="beta"} 0

# HELP tx_cds_beta_jobs_delayed Number of jobs with a delayed status
# TYPE tx_cds_beta_jobs_delayed gauge
tx_cds_beta_jobs_delayed{application="transifex-delivery",environment="beta"} 0
```