### PR TITLE
Add jitter to autosync functionality

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -50,6 +50,12 @@ settings:
   # TX__SETTINGS__AUTOSYNC_MIN=15
   autosync_min: 60
 
+  # A jitter to add to autosync functionality to randomly
+  # distribute cache invalidations over time. Cache will automatically
+  # invalidate at lastUpdate + autosync_min + random(autosync_jitter_min)
+  # TX__SETTINGS__AUTOSYNC_JITTER_MIN=15
+  autosync_jitter_min: 30
+
   # Optionally, a whitelist of project tokens. Set this value if you need
   # to limit access to only a subset of Native Project Tokens, vs having
   # CDS cache everything. e.g.

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -66,7 +66,7 @@ async function routerCacheHelper(req, res, key, filter, syncFunc, ...syncFuncPar
           sentContent = true;
         }
         // check for auto refresh
-        if ((Date.now() - rdata.ts) >= autoSyncMSec) {
+        if ((Date.now() - (rdata.ts + (rdata.ts_jitter || 0))) >= autoSyncMSec) {
           addJob();
         }
         break;

--- a/src/queue/worker.js
+++ b/src/queue/worker.js
@@ -10,6 +10,7 @@ const { sendToTelemetry } = require('../telemetry');
 const pullSuccessExpireSec = config.get('settings:pull_success_cache_min') * 60;
 const pullErrorExpireSec = config.get('settings:pull_error_cache_min') * 60;
 const jobStatusCacheSec = config.get('settings:job_status_cache_min') * 60;
+const autoSyncJitterMin = config.get('settings:autosync_jitter_min') * 1;
 
 /**
  * Pull content from API syncer job
@@ -40,6 +41,7 @@ async function syncerPull(job) {
       registry.set(`cache:${key}`, {
         status: 'success',
         ts: Date.now(),
+        ts_jitter: _.random(autoSyncJitterMin) * 60 * 1000,
         etag,
         location,
         cacheKey,
@@ -70,6 +72,7 @@ async function syncerPull(job) {
         registry.set(`cache:${key}`, {
           status: 'error',
           ts: Date.now(),
+          ts_jitter: _.random(autoSyncJitterMin) * 60 * 1000,
           statusCode,
           statusMessage,
         }, pullErrorExpireSec),


### PR DESCRIPTION
Content is cached in the service for about 1hour unless invalidated. There is already a function in place that if 1hour has elapsed, content will be refreshed.

This can cause some pressure to the system, so with this PR we are adding a random jitter in the auto-sync window to reduce chances that mass amount of content is refreshed at the same time.