### PR TITLE
TX-16451: Remove revisions check from source patch

### DIFF
--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -187,36 +187,6 @@ async function getSourceContentMap(token, options) {
   return Object.fromEntries(concatenatedData);
 }
 
-async function getRevisions(token, options) {
-  const concatenatedData = {};
-  const urlParams = {
-    ORGANIZATION_SLUG: `o:${options.organization_slug}`,
-    PROJECT_SLUG: `p:${options.project_slug}`,
-    RESOURCE_SLUG: `r:${options.resource_slug}`,
-  };
-  if (options.filter_tags) {
-    urlParams.FILTER_TAGS = options.filter_tags;
-  }
-  let url = apiUrls.getUrl('GET_RESOURCE_STRINGS_REVISIONS', urlParams);
-  const headers = apiUrls.getHeaders(token);
-  let result = null;
-  while (url) {
-    logger.info(`GET ${url}`);
-    const { data } = await axios.get(url, headers);
-    url = data.links.next;
-    result = transformer
-      .parseSourceStringRevisionForIdLookup(data.data);
-    Object.entries(result).forEach(([key, value]) => {
-      if (key in concatenatedData) {
-        concatenatedData[key] = [...concatenatedData[key], ...value];
-      } else {
-        concatenatedData[key] = value;
-      }
-    });
-  }
-  return concatenatedData;
-}
-
 /**
  * Makes a GET request to Transifex API to get resource strings on
  * specific keys list and creates a hashmap for quick lookups
@@ -253,42 +223,6 @@ async function getSourceContentMapOnKeys(token, options) {
   }
 
   return Object.fromEntries(concatenatedData);
-}
-
-async function getRevisionsOnKeys(token, options) {
-  const concatenatedData = {};
-
-  const urlKey = 'GET_RESOURCE_STRINGS_REVISIONS_FILTER_KEY';
-  const urlParams = {
-    ORGANIZATION_SLUG: `o:${options.organization_slug}`,
-    PROJECT_SLUG: `p:${options.project_slug}`,
-    RESOURCE_SLUG: `r:${options.resource_slug}`,
-  };
-  const headers = apiUrls.getHeaders(token);
-
-  for (let i = 0; i < options.keys.length; i += 1) {
-    const key = options.keys[i];
-    const url = apiUrls.getUrl(urlKey, {
-      ...urlParams,
-      FILTER_KEY: key,
-    });
-    logger.info(`GET ${url}`);
-    const { data } = await axios.get(url, headers);
-    const result = transformer
-      .parseSourceStringRevisionForIdLookup(data.data);
-    Object.entries(result).forEach(([revisionKey, value]) => {
-      if (revisionKey in concatenatedData) {
-        concatenatedData[revisionKey] = [
-          ...concatenatedData[revisionKey],
-          ...value,
-        ];
-      } else {
-        concatenatedData[revisionKey] = value;
-      }
-    });
-  }
-
-  return concatenatedData;
 }
 
 /**
@@ -487,7 +421,6 @@ async function pushSourceContent(token, options) {
   const deleteTranslationPayloads = [];
 
   let existingStrings = {};
-  let existingRevisions = {};
   let created = 0;
   let updated = 0;
   let skipped = 0;
@@ -531,24 +464,15 @@ async function pushSourceContent(token, options) {
     // if requests to get whole resource are less than the strings to be
     // pushed then fetch the whole resource
     if ((resource.string_count / apiUrls.getPageSize()) < payloadKeys.length) {
-      [existingStrings, existingRevisions] = await Promise.all([
-        getSourceContentMap(token, options),
-        getRevisions(token, options),
-      ]);
+      existingStrings = await getSourceContentMap(token, options);
     } else {
       // ...else fetch details on specific keys we want to upload
-      [existingStrings, existingRevisions] = await Promise.all([
-        getSourceContentMapOnKeys(token, { ...options, keys: payloadKeys }),
-        getRevisionsOnKeys(token, { ...options, keys: payloadKeys }),
-      ]);
+      existingStrings = await getSourceContentMapOnKeys(token, { ...options, keys: payloadKeys });
     }
   } else {
     logger.info(`Purging ${payloadKeys.length} of ${resource.string_count} strings [${resourceId}]`);
     // get all source strings
-    [existingStrings, existingRevisions] = await Promise.all([
-      getSourceContentMap(token, options),
-      getRevisions(token, options),
-    ]);
+    existingStrings = await getSourceContentMap(token, options);
   }
 
   // Create payload for each string
@@ -597,11 +521,9 @@ async function pushSourceContent(token, options) {
       if (!existingString) {
         preparePayloadForPost(attributes);
       } else {
-        const revisions = existingRevisions[existingString.id] || [];
         const mustPatchStrings = apiPayloads.stringContentChanged(
           attributes,
           existingString,
-          revisions,
         );
         const mustPatchMetadata = apiPayloads.stringMetadataChanged(
           attributes,
@@ -708,6 +630,4 @@ module.exports = {
   pushSourceContent,
   patchSourceContent,
   postSourceContent,
-  getRevisions,
-  getRevisionsOnKeys,
 };

--- a/src/services/syncer/strategies/transifex/utils/api_payloads.js
+++ b/src/services/syncer/strategies/transifex/utils/api_payloads.js
@@ -47,16 +47,9 @@ function getDeleteTranslationsPayload(stringId) {
   };
 }
 
-// If the string extracted from the codebase is unknown to Transifex (ie is
-// neither the latest upstream version nor any of the previous revisions), we
-// must update the string on Transifex
-function stringContentChanged(attributes, existingString, revisions) {
+function stringContentChanged(attributes, existingString) {
   return (
     !_.isEqual(attributes.strings, existingString.attributes.strings)
-    && !_.some(
-      revisions,
-      (revision) => _.isEqual(attributes.strings, revision),
-    )
   );
 }
 function stringMetadataChanged(attributes, existingAttributes) {

--- a/src/services/syncer/strategies/transifex/utils/api_urls.js
+++ b/src/services/syncer/strategies/transifex/utils/api_urls.js
@@ -39,13 +39,6 @@ const TRANSIFEX_API_URLS = {
   ORGANIZATIONS: '/organizations',
   PROJECTS: `/projects?filter[organization]=${ENTITY_IDS.ORGANIZATION}`,
   RESOURCES: `/resources?filter[project]=${ENTITY_IDS.PROJECT}`,
-  GET_RESOURCE_STRINGS_REVISIONS: '/resource_strings_revisions?'
-    + `filter[resource_string][resource]=${ENTITY_IDS.RESOURCE}&`
-    + `limit=${PAGE_LIMIT}`,
-  GET_RESOURCE_STRINGS_REVISIONS_FILTER_KEY: '/resource_strings_revisions?'
-    + `filter[resource_string][resource]=${ENTITY_IDS.RESOURCE}&`
-    + `filter[resource_string][key]=${ENTITY_IDS.KEY}&`
-    + `limit=${PAGE_LIMIT}`,
 };
 
 function getUrl(url, parameters) {
@@ -62,9 +55,6 @@ function getUrl(url, parameters) {
     if (parameters.FILTER_TAGS) {
       switch (url) {
         case 'GET_RESOURCE_TRANSLATIONS':
-        case 'GET_RESOURCE_STRINGS_REVISIONS':
-          result = `${result}&filter[resource_string][tags][all]=${parameters.FILTER_TAGS}`;
-          break;
         case 'GET_RESOURCE_STRINGS':
           result = `${result}&filter[tags][all]=${parameters.FILTER_TAGS}`;
           break;

--- a/src/services/syncer/strategies/transifex/utils/transformer.js
+++ b/src/services/syncer/strategies/transifex/utils/transformer.js
@@ -186,20 +186,6 @@ function parseSourceStringForKeyLookup(payload) {
   return data;
 }
 
-function parseSourceStringRevisionForIdLookup(payload) {
-  const data = {};
-  if (!payload) return data;
-  payload.forEach((resourceStringRevision) => {
-    const {
-      attributes: { strings },
-      relationships: { resource_string: { data: { id: resourceStringId } } },
-    } = resourceStringRevision;
-    data[resourceStringId] = data[resourceStringId] || [];
-    data[resourceStringId].push(strings);
-  });
-  return data;
-}
-
 /**
  * Transform a payload to a Transifex API V3 string push
  *
@@ -255,5 +241,4 @@ module.exports = {
   parseSourceStringForKeyLookup,
   parseSourceStringForIdLookup,
   getStringFromSourceEntity,
-  parseSourceStringRevisionForIdLookup,
 };

--- a/tests/routes/content.spec.js
+++ b/tests/routes/content.spec.js
@@ -30,9 +30,6 @@ const urls = {
     + 'o:oslug:p:pslug:r:rslug&'
     + `limit=${config.get('transifex:page_limit')}`,
   resource_strings: '/resource_strings',
-  source_strings_revisions: '/resource_strings_revisions?'
-    + 'filter[resource_string][resource]=o:oslug:p:pslug:r:rslug&'
-    + 'limit=1000',
 };
 
 function sleep(ms) {
@@ -293,9 +290,6 @@ describe('POST /content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
       .reply(200, {
@@ -349,9 +343,6 @@ describe('POST /content', () => {
   it('should discard empty keys of strings', async () => {
     nock(urls.api)
       .get(urls.source_strings)
-      .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
       .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
@@ -419,9 +410,6 @@ describe('POST /content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
       .reply(400, {
@@ -488,9 +476,6 @@ describe('POST /content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
       .reply(200, {});
@@ -537,9 +522,6 @@ describe('POST /content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api)
       .post(urls.resource_strings)
@@ -589,9 +571,6 @@ describe('POST /content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api)
       .post(urls.resource_strings)
@@ -620,67 +599,6 @@ describe('POST /content', () => {
         details: {
           created: 0,
           updated: 0,
-          skipped: 0,
-          deleted: 0,
-          failed: 0,
-        },
-        errors: [],
-        status: 'completed',
-      },
-    });
-  });
-
-  it('should patch source strings if new', async () => {
-    const sourceData = dataHelper.getSourceString();
-    nock(urls.api)
-      .get(urls.source_strings)
-      .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .patch(`${urls.resource_strings}/${sourceData.data[0].id}`)
-      .reply(200, {
-        data: [{
-          someotherkey: 'someothervalue',
-        }],
-      });
-    const data = {
-      hello_world: {
-        string: '{cnt, plural, one {Hello} other {World}}',
-        meta: {
-          context: 'frontpage:footer:verb',
-          character_limit: 100,
-          tags: ['foo', 'bar'],
-          developer_comment: 'Wrapped in a 30px width div',
-          occurrences: ['/my_project/templates/frontpage/hello.html:30'],
-        },
-      },
-    };
-    let res = await request(app)
-      .post('/content')
-      .set('Accept-version', 'v2')
-      .set('Authorization', `Bearer ${token}:secret`)
-      .send({ data });
-    expect(res.status).to.eql(202);
-
-    // poll
-    let status = '';
-    const jobUrl = res.body.data.links.job;
-    while (status !== 'completed') {
-      await sleep(100);
-      res = await request(app)
-        .get(jobUrl)
-        .set('Authorization', `Bearer ${token}:secret`);
-      expect(res.status).to.eql(200);
-      status = res.body.data.status;
-    }
-
-    expect(res.body).to.eqls({
-      data: {
-        details: {
-          created: 0,
-          updated: 1,
           skipped: 0,
           deleted: 0,
           failed: 0,

--- a/tests/services/syncer/strategies/transifex/data.spec.js
+++ b/tests/services/syncer/strategies/transifex/data.spec.js
@@ -37,9 +37,6 @@ const urls = {
     + 'o:oslug:p:pslug:r:rslug&'
     + `limit=${config.get('transifex:page_limit')}`,
   resource_strings: '/resource_strings',
-  source_strings_revisions: '/resource_strings_revisions?'
-    + 'filter[resource_string][resource]=o:oslug:p:pslug:r:rslug&'
-    + 'limit=1000',
 };
 
 describe('Get token information', () => {
@@ -433,9 +430,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
       .reply(200, {
@@ -465,9 +459,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     const data = dataHelper.getPushSourceContent();
     const result = await transifexData.pushSourceContent(options, data, {
@@ -487,9 +478,6 @@ describe('Push source Content', () => {
   it('should return correct report on errors', async () => {
     nock(urls.api)
       .get(urls.source_strings)
-      .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
       .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
@@ -534,9 +522,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     // mock from cds -> api
     nock(urls.api).post(urls.resource_strings)
@@ -575,9 +560,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
       .reply(200, {
@@ -606,9 +588,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api)
       .post(urls.resource_strings)
@@ -647,9 +626,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
       .reply(200, {
@@ -692,9 +668,6 @@ describe('Push source Content', () => {
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
 
     // cds -> api
     nock(urls.api)
@@ -737,9 +710,6 @@ describe('Push source Content', () => {
       .get(urls.source_strings)
       .reply(200, sourceData);
     nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
-    nock(urls.api)
       .patch(`${urls.resource_strings}/${sourceData.data[0].id}`)
       .reply(200, {
         data: [{
@@ -772,56 +742,11 @@ describe('Push source Content', () => {
     });
   });
 
-  it('should skip patch source strings if in revisions', async () => {
-    const sourceData = dataHelper.getSourceString();
-    nock(urls.api)
-      .get(urls.source_strings)
-      .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, {
-        data: [{
-          attributes: { strings: { one: 'Hello', other: 'World' } },
-          relationships: {
-            resource_string: { data: { id: sourceData.data[0].id } },
-          },
-        }],
-        links: {},
-      });
-    const result = await transifexData.pushSourceContent(
-      options,
-      {
-        hello_world: {
-          string: '{cnt, plural, one {Hello} other {World}}',
-          meta: {
-            context: 'frontpage:footer:verb',
-            character_limit: 100,
-            tags: ['foo', 'bar'],
-            developer_comment: 'Wrapped in a 30px width div',
-            occurrences: ['/my_project/templates/frontpage/hello.html:30'],
-          },
-        },
-      },
-      {},
-    );
-    expect(result).to.eql({
-      created: 0,
-      updated: 0,
-      skipped: 1,
-      deleted: 0,
-      failed: 0,
-      errors: [],
-    });
-  });
-
   it('should patch source strings if new with purge', async () => {
     const sourceData = dataHelper.getSourceString();
     nock(urls.api)
       .get(urls.source_strings)
       .reply(200, sourceData);
-    nock(urls.api)
-      .get(urls.source_strings_revisions)
-      .reply(200, { data: [], links: {} });
     nock(urls.api)
       .patch(`${urls.resource_strings}/${sourceData.data[0].id}`)
       .reply(200, {
@@ -909,14 +834,7 @@ describe('Push source Content (per string key strategy)', () => {
       .get(`${urls.source_strings}&filter[key]=somekey`)
       .reply(200, { data: [], links: {} });
     nock(urls.api)
-      .get(`${urls.source_strings_revisions}&filter[resource_string][key]=somekey`)
-      .reply(200, { data: [], links: {} });
-
-    nock(urls.api)
       .get(`${urls.source_strings}&filter[key]=hello_world`)
-      .reply(200, { data: [], links: {} });
-    nock(urls.api)
-      .get(`${urls.source_strings_revisions}&filter[resource_string][key]=hello_world`)
       .reply(200, { data: [], links: {} });
 
     nock(urls.api).post(urls.resource_strings)
@@ -949,9 +867,6 @@ describe('Push source Content (per string key strategy)', () => {
       .get(`${urls.source_strings}&filter[key]=hello_world`)
       .reply(200, sourceData);
     nock(urls.api)
-      .get(`${urls.source_strings_revisions}&filter[resource_string][key]=hello_world`)
-      .reply(200, { data: [], links: {} });
-    nock(urls.api)
       .patch(`${urls.resource_strings}/${sourceData.data[0].id}`)
       .reply(200, {
         data: [{
@@ -978,48 +893,6 @@ describe('Push source Content (per string key strategy)', () => {
       created: 0,
       updated: 1,
       skipped: 0,
-      deleted: 0,
-      failed: 0,
-      errors: [],
-    });
-  });
-
-  it('should skip patch source strings if in revisions', async () => {
-    const sourceData = dataHelper.getSourceString();
-    nock(urls.api)
-      .get(`${urls.source_strings}&filter[key]=hello_world`)
-      .reply(200, sourceData);
-    nock(urls.api)
-      .get(`${urls.source_strings_revisions}&filter[resource_string][key]=hello_world`)
-      .reply(200, {
-        data: [{
-          attributes: { strings: { one: 'Hello', other: 'World' } },
-          relationships: {
-            resource_string: { data: { id: sourceData.data[0].id } },
-          },
-        }],
-        links: {},
-      });
-    const result = await transifexData.pushSourceContent(
-      options,
-      {
-        hello_world: {
-          string: '{cnt, plural, one {Hello} other {World}}',
-          meta: {
-            context: 'frontpage:footer:verb',
-            character_limit: 100,
-            tags: ['foo', 'bar'],
-            developer_comment: 'Wrapped in a 30px width div',
-            occurrences: ['/my_project/templates/frontpage/hello.html:30'],
-          },
-        },
-      },
-      {},
-    );
-    expect(result).to.eql({
-      created: 0,
-      updated: 0,
-      skipped: 1,
       deleted: 0,
       failed: 0,
       errors: [],


### PR DESCRIPTION
Related to [TX-16451: Native CDS is not updating strings every time when pushing small changes to strings](https://xtm-cloud.atlassian.net/browse/TX-16451)

# Problem
Pushing source edits fails when the new edit matches a previously existing version.

This happens because we keep a revision list of all past source string updates. When a new update is submitted, the system checks this list, and if the string is already there, the update is skipped.

This creates inconsistency and confusion, since editing a source string through the editor does not have the same restriction — you can freely revert to a previous version without issue.

This PR removes the revision list check so that every source edit is always recorded.

# Test

To test it:
1. Crate a native project
2. Create a source string (for example hello world)
3. Use the sdk to update the source string (for example hello world2)
4. Update the source string again (using the sdk) to the first version (hello world)
5. The update should appear

To use the sdk use the following example code (python):
```
from __future__ import absolute_import

from transifex.native import init, tx
from transifex.native.parsing import SourceString

init('token', ['el', 'en'], 'secret')

source1 = SourceString(u'Hello world!',
            _key="unique_key_1",
            _context=u'one,two,three',
            _comment=u'A crucial comment',
            _charlimit=33,
            _tags=u' t1,t2,t3')

response_code, response_content = tx.push_source_strings([source1])
```

To test it locally:
You also need to use the local transifex-delivery endpoint with the sdk.
In the python sdk code, change the request url in the **push_source_strings** method to **http://localhost:10300/content/** and start the transifex-delivery server.