### PR TITLE
TX-15487: Pass keep_translations option to resource string request

### DIFF
--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -516,11 +516,6 @@ async function pushSourceContent(token, options) {
     deletePayloads.push(payload);
   }
 
-  function preparePayloadForDeleteTranslations(key) {
-    const payload = apiPayloads.getDeleteTranslationsPayload(existingStrings[key].id);
-    deleteTranslationPayloads.push(payload);
-  }
-
   const payloadKeys = _.keys(strings);
   // check for optimal strategy to update content, reducing API calls
   const resource = await getResource(token, options);
@@ -592,6 +587,8 @@ async function pushSourceContent(token, options) {
             ),
           )).join(',');
         }
+
+        attributes.keep_translations = meta.keep_translations;
       }
 
       if (!existingString) {
@@ -625,9 +622,6 @@ async function pushSourceContent(token, options) {
 
         if (mustPatchStrings || mustPatchMetadata) {
           preparePayloadForPatch(key, attributes, mustPatchStrings);
-          if (mustPatchStrings && meta.keep_translations === false) {
-            preparePayloadForDeleteTranslations(key);
-          }
         } else {
           skipped += 1;
         }

--- a/src/services/syncer/strategies/transifex/utils/api_payloads.js
+++ b/src/services/syncer/strategies/transifex/utils/api_payloads.js
@@ -1,6 +1,12 @@
 const _ = require('lodash');
 
-const PATCH_ATTRIBUTES = ['character_limit', 'tags', 'developer_comment', 'occurrences'];
+const PATCH_ATTRIBUTES = [
+  'character_limit',
+  'tags',
+  'developer_comment',
+  'occurrences',
+  'keep_translations',
+];
 
 function getPushStringPayload(resourceId, attributes) {
   return {
@@ -34,16 +40,6 @@ function getDeleteStringPayload(stringId) {
   return {
     id: stringId,
     type: 'resource_strings',
-  };
-}
-
-function getDeleteTranslationsPayload(stringId) {
-  return {
-    attributes: {
-      strings: null,
-    },
-    id: stringId,
-    type: 'resource_translations',
   };
 }
 
@@ -85,7 +81,6 @@ module.exports = {
   getPushStringPayload,
   getPatchStringPayload,
   getDeleteStringPayload,
-  getDeleteTranslationsPayload,
   stringMetadataChanged,
   stringContentChanged,
 };

--- a/tests/services/syncer/strategies/transifex/data.spec.js
+++ b/tests/services/syncer/strategies/transifex/data.spec.js
@@ -772,6 +772,88 @@ describe('Push source Content', () => {
     });
   });
 
+  it('should patch source strings if new with keep_translations', async () => {
+    const sourceData = dataHelper.getSourceString();
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, sourceData);
+    nock(urls.api)
+      .get(urls.source_strings_revisions)
+      .reply(200, { data: [], links: {} });
+    nock(urls.api)
+      .patch(`${urls.resource_strings}/${sourceData.data[0].id}`)
+      .reply(200, {
+        data: [{
+          someotherkey: 'someothervalue',
+        }],
+      });
+    const result = await transifexData.pushSourceContent(
+      options,
+      {
+        hello_world: {
+          string: '{cnt, plural, one {Hello} other {World}}',
+          meta: {
+            context: 'frontpage:footer:verb',
+            character_limit: 100,
+            tags: ['foo', 'bar'],
+            developer_comment: 'Wrapped in a 30px width div',
+            occurrences: ['/my_project/templates/frontpage/hello.html:30'],
+          },
+        },
+      },
+      { meta: { keep_translations: true } },
+    );
+    expect(result).to.eql({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      deleted: 0,
+      failed: 0,
+      errors: [],
+    });
+  });
+
+  it('should patch source strings if new without keep_translations', async () => {
+    const sourceData = dataHelper.getSourceString();
+    nock(urls.api)
+      .get(urls.source_strings)
+      .reply(200, sourceData);
+    nock(urls.api)
+      .get(urls.source_strings_revisions)
+      .reply(200, { data: [], links: {} });
+    nock(urls.api)
+      .patch(`${urls.resource_strings}/${sourceData.data[0].id}`)
+      .reply(200, {
+        data: [{
+          someotherkey: 'someothervalue',
+        }],
+      });
+    const result = await transifexData.pushSourceContent(
+      options,
+      {
+        hello_world: {
+          string: '{cnt, plural, one {Hello} other {World}}',
+          meta: {
+            context: 'frontpage:footer:verb',
+            character_limit: 100,
+            tags: ['foo', 'bar'],
+            developer_comment: 'Wrapped in a 30px width div',
+            occurrences: ['/my_project/templates/frontpage/hello.html:30'],
+          },
+        },
+      },
+      { meta: { keep_translations: false } },
+    );
+    expect(result).to.eql({
+      created: 0,
+      updated: 1,
+      skipped: 0,
+      deleted: 0,
+      failed: 0,
+      errors: [],
+    });
+  });
+
   it('should skip patch source strings if in revisions', async () => {
     const sourceData = dataHelper.getSourceString();
     nock(urls.api)


### PR DESCRIPTION
Related to [TX-15487: Add parameter "keep_translations"to the API endpoint "Update a resource string"](https://xtm-cloud.atlassian.net/browse/TX-15487)

Related PRs
[1# openai](https://github.com/transifex/openapi/pull/487)
[2# transifex-api-v3](https://github.com/transifex/transifex-api-v3/pull/1268)

# Problem

We should allow the user when updating a source string to decide whether they want to keep or delete any existing translations.

Also this PR resolves the issue described [here](https://xtm-cloud.atlassian.net/browse/TX-16382).

> When the customer updates a source string via the SDK with --do-not-keep-translations flag, the system should discard the existing translations and reflect only the source change. Instead, the string history incorrectly shows translation actions (translated, reviewed, unreviewed, deleted) at the same timestamp as the update, including actions marked as done via the Editor, even though the update was fully automated through the SDK.

This is causing confusion and concern, as it falsely appears that a user manually added and reviewed translations.

# Test

1. Crate a native project
2. Create a source string (for example hello world)
3. Add a translation
4. Use the cli with --do-not-keep-translations to update the source string (for example hello world2)
6. Check the history, you should see Source Edited by username, a few seconds ago via API & Translation deleted by username, a few seconds ago via API

To use the cli add the following example code (js) in a .js file and download the [js sdk](https://developers.transifex.com/docs/javascript-sdk-setup):
```
t('This is a test', {
  _key: 'string1',
});
```

Then run:
```
npx txjs-cli push js.js --token=your_token --secret=your_secret --do-not-keep-translations
```

## To test it locally:

Change the cds host in `node_modules/@transifex/cli/src/commands/push.js (line 145)` to `http://127.0.0.1:10300`.

Change the transifex api host in `transifex-delivery/src/services/syncer/strategies/transifex/utils/api_urls.js` to `http://apiv3-web:8004`.

Clone openai repo locally and switch to branch TX-15487.

Mount local openai in transifex-api-v3. To do this visit docker-compose.yml in the transifex-api-v3 repo and add the following in apiv3-web volumes:
```
- /home/your_username/transifex/openapi/txapi_spec:/usr/local/lib/python3.9/site-packages/txapi_spec
```
Finally start the transifex-api-v3 and transifex-delivery servers.