### PR TITLE
Mitigate DynamoDB ThrottlingException

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -108,6 +108,12 @@ dynamodb:
   # TX__DYNAMODB__TABLE_NAME=mytable
   table_name: transifex-delivery
 
+  # Number of shards for distributing set keys across DynamoDB partitions.
+  # This prevents hot key throttling by spreading writes to
+  # cache:${token}:keys across multiple partition keys.
+  # TX__DYNAMODB__KEY_SHARDS=5
+  key_shards: 5
+
 registry:
   # Prefix namespace for registry in Redis. Modify if you want to separate
   # data, between multiple environments (e.g. beta, staging) that are using

--- a/src/services/registry/strategies/dynamodb-redis/index.js
+++ b/src/services/registry/strategies/dynamodb-redis/index.js
@@ -114,25 +114,50 @@ async function incr(key, increment, expireSec) {
 
 /**
  * @implements {addToSet}
+ *
+ * Writes to both Redis and DynamoDB in parallel.
+ * Redis eliminates read pressure; DynamoDB provides persistence.
+ * Redis result is authoritative for the return value.
  */
 async function addToSet(key, value, expireSec) {
-  const retVal = await dynamodb.addToSet(key, value, expireSec);
-  return retVal;
+  const [redisResult] = await Promise.all([
+    redis.addToSet(key, value, expireSec),
+    dynamodb.addToSet(key, value, expireSec),
+  ]);
+  return redisResult;
 }
 
 /**
  * @implements {delFromSet}
+ *
+ * Deletes from both Redis and DynamoDB in parallel.
+ * Redis result is authoritative for the return value.
  */
 async function delFromSet(key, value) {
-  const retVal = await dynamodb.delFromSet(key, value);
-  return retVal;
+  const [redisResult] = await Promise.all([
+    redis.delFromSet(key, value),
+    dynamodb.delFromSet(key, value),
+  ]);
+  return redisResult;
 }
 
 /**
  * @implements {listSet}
+ *
+ * Reads from Redis first. On a miss (cold start or Redis restart),
+ * falls back to DynamoDB and populates Redis for subsequent reads.
  */
-function listSet(key) {
-  return dynamodb.listSet(key);
+async function listSet(key) {
+  const redisValues = await redis.listSet(key);
+  if (redisValues.length > 0) {
+    return redisValues;
+  }
+  // Redis miss — fall back to DynamoDB and warm Redis
+  const dynamoValues = await dynamodb.listSet(key);
+  if (dynamoValues.length > 0) {
+    await Promise.all(dynamoValues.map((v) => redis.addToSet(key, v)));
+  }
+  return dynamoValues;
 }
 
 /**

--- a/src/services/registry/strategies/dynamodb/index.js
+++ b/src/services/registry/strategies/dynamodb/index.js
@@ -17,7 +17,33 @@ if (commonConfig || dynamodbConfig) {
 }
 
 const tableName = config.get('dynamodb:table_name');
-const docClient = new AWS.DynamoDB.DocumentClient(awsConfig);
+const docClient = new AWS.DynamoDB.DocumentClient({
+  ...awsConfig,
+  maxRetries: 5,
+  retryDelayOptions: {
+    customBackoff: (retryCount) => Math.min(2 ** retryCount * 50, 3000),
+  },
+});
+
+const parsedShards = parseInt(config.get('dynamodb:key_shards'), 10);
+const NUM_SHARDS = Number.isFinite(parsedShards) && parsedShards > 0 ? parsedShards : 5;
+
+/**
+ * Simple string hash to deterministically assign a value to a shard.
+ *
+ * @param {String} str
+ * @returns {Number} shard index (0 to NUM_SHARDS-1)
+ */
+function getShardIndex(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    // eslint-disable-next-line no-bitwise
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash) % NUM_SHARDS;
+}
 
 /**
  * Convert a user key to DynamoDB key with prefix included
@@ -148,9 +174,14 @@ async function incr(key, increment, expireSec) {
 }
 
 /**
- * @implements {addToSet}
+ * Internal addToSet that operates on a single DynamoDB key (no sharding).
+ *
+ * @param {String} key
+ * @param {String} value
+ * @param {Number} expireSec
+ * @returns {Promise<Boolean>}
  */
-async function addToSet(key, value, expireSec) {
+async function addToSetSingle(key, value, expireSec) {
   const ttl = expireSec > 0
     ? Math.round(Date.now() / 1000) + expireSec
     : undefined;
@@ -167,7 +198,7 @@ async function addToSet(key, value, expireSec) {
         '#ttl': 'ttl',
       },
       ExpressionAttributeValues: {
-        ':set': docClient.createSet([value]),
+        ':set': docClient.createSet([`${value}`]),
         ':ttl': ttl,
       },
       UpdateExpression: 'ADD #value :set SET #ttl = :ttl',
@@ -196,9 +227,13 @@ async function addToSet(key, value, expireSec) {
 }
 
 /**
- * @implements {delFromSet}
+ * Internal delFromSet that operates on a single DynamoDB key (no sharding).
+ *
+ * @param {String} key
+ * @param {String} value
+ * @returns {Promise<Boolean>}
  */
-async function delFromSet(key, value) {
+async function delFromSetSingle(key, value) {
   const params = {
     TableName: tableName,
     Key: {
@@ -220,11 +255,76 @@ async function delFromSet(key, value) {
 }
 
 /**
- * @implements {listSet}
+ * Internal listSet that reads a single DynamoDB key (no sharding).
+ *
+ * @param {String} key
+ * @returns {Promise<Array>}
  */
-async function listSet(key) {
+async function listSetSingle(key) {
   const value = await get(key);
   return (value || {}).values || [];
+}
+
+/**
+ * @implements {addToSet}
+ *
+ * Writes to a sharded key based on a hash of the value.
+ * This distributes writes across NUM_SHARDS DynamoDB partitions
+ * to avoid hot key throttling.
+ */
+async function addToSet(key, value, expireSec) {
+  const shard = getShardIndex(`${value}`);
+  const shardKey = `${key}:${shard}`;
+  const [legacyValues, shardResult] = await Promise.all([
+    listSetSingle(key),
+    addToSetSingle(shardKey, value, expireSec),
+  ]);
+  const existsInLegacy = legacyValues.indexOf(`${value}`) !== -1;
+  return !existsInLegacy && shardResult;
+}
+
+/**
+ * @implements {delFromSet}
+ *
+ * Deletes from the correct shard (determined by hashing the value).
+ * Also deletes from the legacy unsharded key if the value is present there,
+ * for backward compatibility with pre-sharding data. The legacy delete is
+ * conditional to avoid recreating an empty DynamoDB item after the legacy
+ * key's TTL has expired.
+ */
+async function delFromSet(key, value) {
+  const shard = getShardIndex(`${value}`);
+  const shardKey = `${key}:${shard}`;
+
+  const legacyValues = await listSetSingle(key);
+  const legacyHasValue = legacyValues.indexOf(`${value}`) !== -1;
+
+  const ops = [delFromSetSingle(shardKey, value)];
+  if (legacyHasValue) {
+    ops.push(delFromSetSingle(key, value));
+  }
+
+  const results = await Promise.all(ops);
+  return results.some(Boolean);
+}
+
+/**
+ * @implements {listSet}
+ *
+ * Reads from all shards in parallel and merges results.
+ * Also reads the legacy unsharded key for backward compatibility
+ * with pre-sharding data.
+ */
+async function listSet(key) {
+  const shardKeys = [];
+  for (let i = 0; i < NUM_SHARDS; i += 1) {
+    shardKeys.push(`${key}:${i}`);
+  }
+  const results = await Promise.all([
+    listSetSingle(key), // legacy unsharded key
+    ..._.map(shardKeys, (sk) => listSetSingle(sk)),
+  ]);
+  return _.uniq(_.flatten(results));
 }
 
 /**

--- a/tests/services/registry/strategies/dynamodb-redis/registry.spec.js
+++ b/tests/services/registry/strategies/dynamodb-redis/registry.spec.js
@@ -3,6 +3,8 @@
 const { expect } = require('chai');
 const _ = require('lodash');
 const registry = require('../../../../../src/services/registry/strategies/dynamodb-redis');
+const redisStrategy = require('../../../../../src/services/registry/strategies/redis');
+const dynamodbStrategy = require('../../../../../src/services/registry/strategies/dynamodb');
 
 describe('DynamoDB-Redis registry', () => {
   before(async () => {
@@ -10,10 +12,13 @@ describe('DynamoDB-Redis registry', () => {
   });
 
   beforeEach(async () => {
-    const keys = await registry.findAll();
-    await Promise.all(_.map(keys, (key) => (async () => {
-      await registry.del(key);
-    })()));
+    // Clean DynamoDB keys (includes shard keys like key:0..4)
+    const dynamoKeys = await registry.findAll();
+    // Clean Redis keys — Set base keys are not tracked in DynamoDB due to sharding,
+    // so they must be cleaned separately to prevent cross-test contamination.
+    const redisKeys = await redisStrategy._find('*');
+    const allKeys = _.uniq([...dynamoKeys, ...redisKeys]);
+    await Promise.all(allKeys.map((key) => registry.del(key)));
   });
 
   it('should write to registry', async () => {
@@ -93,10 +98,45 @@ describe('DynamoDB-Redis registry', () => {
     expect(await registry.delFromSet('test:del_from_set', 'a')).to.equal(false);
 
     let values = await registry.listSet('test:del_from_set');
-    expect(values).to.deep.equal(['b']);
+    expect(values.sort()).to.deep.equal(['b']);
 
     expect(await registry.delFromSet('test:del_from_set', 'b')).to.equal(true);
     values = await registry.listSet('test:del_from_set');
     expect(values).to.deep.equal([]);
+  });
+
+  it('listSet returns empty array for a key that has never been written', async () => {
+    // Arrange - no setup, key does not exist in DynamoDB or any shard
+    // Act
+    const values = await registry.listSet('test:nonexistent_sharded_set');
+    // Assert
+    expect(values).to.deep.equal([]);
+  });
+
+  it('addToSet and listSet handle a set spanning all shards including duplicate shards', async () => {
+    // Arrange
+    // Shard assignments (NUM_SHARDS=5): a→2, b→3, c→4, d→0, e→1, f→2
+    // 'a' and 'f' share shard 2 — exercises multi-value-per-shard behavior
+    const entries = ['a', 'b', 'c', 'd', 'e', 'f'];
+    // Act
+    await Promise.all(entries.map((v) => registry.addToSet('test:all_shards_set', v)));
+    const result = await registry.listSet('test:all_shards_set');
+    // Assert
+    expect(result.sort()).to.deep.equal(entries.sort());
+  });
+
+  it('listSet falls back to DynamoDB and populates Redis on cache miss', async () => {
+    // Arrange - write directly to DynamoDB, bypassing Redis
+    await dynamodbStrategy.addToSet('test:dynamo_fallback', 'a');
+    await dynamodbStrategy.addToSet('test:dynamo_fallback', 'b');
+
+    // Act - listSet should fall back to DynamoDB (Redis has no entry)
+    const result = await registry.listSet('test:dynamo_fallback');
+    // Assert
+    expect(result.sort()).to.deep.equal(['a', 'b']);
+
+    // Subsequent call should be served from Redis (DynamoDB not needed)
+    const cached = await registry.listSet('test:dynamo_fallback');
+    expect(cached.sort()).to.deep.equal(['a', 'b']);
   });
 });

--- a/tests/services/registry/strategies/dynamodb-redis/registry.spec.js
+++ b/tests/services/registry/strategies/dynamodb-redis/registry.spec.js
@@ -16,7 +16,7 @@ describe('DynamoDB-Redis registry', () => {
     const dynamoKeys = await registry.findAll();
     // Clean Redis keys — Set base keys are not tracked in DynamoDB due to sharding,
     // so they must be cleaned separately to prevent cross-test contamination.
-    const redisKeys = await redisStrategy._find('*');
+    const redisKeys = await redisStrategy.findAll();
     const allKeys = _.uniq([...dynamoKeys, ...redisKeys]);
     await Promise.all(allKeys.map((key) => registry.del(key)));
   });

--- a/tests/services/registry/strategies/dynamodb/registry.spec.js
+++ b/tests/services/registry/strategies/dynamodb/registry.spec.js
@@ -79,6 +79,12 @@ describe('DynamoDB registry', () => {
     expect((await registry.listSet('test:add_to_set_ttl')).length).to.equal(2);
   });
 
+  it('returns false when value already exists in legacy unsharded set', async () => {
+    await registry.set('test:legacy_add_to_set', { values: ['a'] });
+    expect(await registry.addToSet('test:legacy_add_to_set', 'a')).to.equal(false);
+    expect((await registry.listSet('test:legacy_add_to_set')).sort()).to.deep.equal(['a']);
+  });
+
   it('lists set', async () => {
     await registry.addToSet('test:list_set', 'a');
     await registry.addToSet('test:list_set', 'b');
@@ -93,10 +99,64 @@ describe('DynamoDB registry', () => {
     expect(await registry.delFromSet('test:del_from_set', 'a')).to.equal(false);
 
     let values = await registry.listSet('test:del_from_set');
-    expect(values).to.deep.equal(['b']);
+    expect(values.sort()).to.deep.equal(['b']);
 
     expect(await registry.delFromSet('test:del_from_set', 'b')).to.equal(true);
     values = await registry.listSet('test:del_from_set');
     expect(values).to.deep.equal([]);
+  });
+
+  it('listSet returns empty array for a key that has never been written', async () => {
+    // Arrange - no setup, key does not exist in DynamoDB or any shard
+    // Act
+    const values = await registry.listSet('test:nonexistent_sharded_set');
+    // Assert
+    expect(values).to.deep.equal([]);
+  });
+
+  it('addToSet and listSet handle a set spanning all shards including duplicate shards', async () => {
+    // Arrange
+    // Shard assignments (NUM_SHARDS=5): a→2, b→3, c→4, d→0, e→1, f→2
+    // 'a' and 'f' share shard 2 — exercises multi-value-per-shard behavior
+    const entries = ['a', 'b', 'c', 'd', 'e', 'f'];
+    // Act
+    await Promise.all(entries.map((v) => registry.addToSet('test:all_shards_set', v)));
+    const result = await registry.listSet('test:all_shards_set');
+    // Assert
+    expect(result.sort()).to.deep.equal(entries.sort());
+  });
+
+  it('listSet returns all values when multiple values exist in unsharded legacy data', async () => {
+    // Arrange - simulate a token written before sharding was introduced
+    const legacyValues = ['cache:tok:en:content', 'cache:tok:fr:content', 'cache:tok:de:content'];
+    await registry.set('test:legacy_multi_values', { values: legacyValues });
+    // Act
+    const result = await registry.listSet('test:legacy_multi_values');
+    // Assert
+    expect(result.sort()).to.deep.equal(legacyValues.sort());
+  });
+
+  it('listSet deduplicates a value present in both the legacy key and a shard key', async () => {
+    // Arrange - seed 'a' in the legacy key, then addToSet 'a' (it also lands in shard 2)
+    // and add 'b' as a new shard-only value
+    await registry.set('test:shard_dedup_set', { values: ['a'] });
+    await registry.addToSet('test:shard_dedup_set', 'a'); // 'a' now exists in legacy AND shard 2
+    await registry.addToSet('test:shard_dedup_set', 'b'); // 'b' only in shard 3
+    // Act
+    const result = await registry.listSet('test:shard_dedup_set');
+    // Assert - 'a' appears exactly once despite being in two places
+    expect(result.sort()).to.deep.equal(['a', 'b']);
+  });
+
+  it('addToSet writes to a shard sub-key and leaves the base key empty', async () => {
+    // Arrange - 'a' hashes to shard 2 (charCode 97, 97 % 5 = 2)
+    await registry.addToSet('test:shard_key_placement', 'a');
+    // Act
+    const baseKeyData = await registry.get('test:shard_key_placement');
+    const shardKeyData = await registry.get('test:shard_key_placement:2');
+    // Assert
+    expect(baseKeyData).to.equal(undefined);
+    expect(shardKeyData).to.not.equal(undefined);
+    expect(shardKeyData.values).to.include('a');
   });
 });


### PR DESCRIPTION
Attempt to mitigate dynamodb TrhottlingException:
- Apply [write sharding](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-sharding.html) to the hot key pattern `cache:${project_token}:keys`:
     - **Write:** Use `cache:${project_token}:keys#${shardId}` where `shardId = hash(value) % N` (e.g., N=10–50)
     - **Read:** Query all shards and merge results for `listSet`
     - Note: Backward compatibility — listSet reads both sharded keys and the legacy unsharded key; delFromSet removes from both when the value exists in legacy data, update would work work on new keys. Existing data continues to work without migration.
- DynamoDB DocumentClient configured with maxRetries: 5 and customBackoff (exponential, capped at 3s) so transient throttling is retried more aggressively https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/retry-strategy.html
- DynamoDB-Redis strategy — addToSet and delFromSet now write to Redis and DynamoDB in parallel; listSet reads from Redis first and falls back to DynamoDB on miss (in this way we avoid making 6 calls at dynamodb -> 5 shards and legacy key to collect all data)
