### PR TITLE
Implement functionality to allow force source update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #####################
 ### builder image ###
 
-FROM node:20.12.2-alpine as builder
+FROM node:20.12.2-alpine AS builder
 
 ARG USER_ID
 ARG GROUP_ID
@@ -24,7 +24,7 @@ EXPOSE 10300 9090
 
 ##########################
 #### production image ###
-FROM builder as transifex-delivery
+FROM builder AS transifex-delivery
 
 ENV NODE_ENV=production
 
@@ -40,7 +40,7 @@ CMD ["npm", "start"]
 
 ##########################
 #### devel image ###
-FROM builder as transifex-delivery-devel
+FROM builder AS transifex-delivery-devel
 
 ENV NODE_ENV=development
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ if `keep_translations: false` in `meta` object, then delete translations on sour
 
 If `dry_run: true` in `meta` object, then emulate a content push, without doing actual changes.
 
+**Force update source**
+if `force_source_update: true` in `meta` the source will always be updated regardless of the revisions
+
 ```
 POST /content
 

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -18,6 +18,7 @@ const PUSH_SOURCE_CONTENT_META_SCHEMA = joi.object().keys({
   override_occurrences: joi.boolean(),
   keep_translations: joi.boolean(),
   dry_run: joi.boolean(),
+  force_source_update: joi.boolean(),
 });
 
 /**

--- a/src/services/syncer/data.js
+++ b/src/services/syncer/data.js
@@ -96,7 +96,8 @@ async function getProjectLanguageTranslations(options, langCode) {
  *     override_tags: <boolean>,
  *     override_occurrences: <boolean>,
  *     keep_translations: <boolean>,
- *     dry_run: <boolean>
+ *     dry_run: <boolean>,
+ *     force_source_update: <boolean>,
  *   },
  * }
  *

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -652,20 +652,18 @@ async function pushSourceContent(token, options) {
         preparePayloadForPost(attributes, key);
       } else {
         const revisions = existingRevisions[existingString.id] || [];
-        let mustPatchStrings = apiPayloads.stringContentChanged(
+        const forceUpdate = options.organization_slug === 'tikogames'
+          || meta.force_source_update === true;
+        const mustPatchStrings = apiPayloads.stringContentChanged(
           attributes,
           existingString,
           revisions,
+          forceUpdate,
         );
         const mustPatchMetadata = apiPayloads.stringMetadataChanged(
           attributes,
           existingString.attributes,
         );
-        // Temporary fix for tikogames org to always update strings
-        // until we implement the update_previous_source_strings flag
-        if (options.organization_slug === 'tikogames' || meta.force_source_update === true) {
-          mustPatchStrings = true;
-        }
 
         // Log the organization accessing the revision list
         // This helps us track usage and identify which orgs are actively using it

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -668,7 +668,7 @@ async function pushSourceContent(token, options) {
         // Log the organization accessing the revision list
         // This helps us track usage and identify which orgs are actively using it
         // so we can reach out if we plan to disable this feature in the future
-        if (_.some(
+        if (!forceUpdate && _.some(
           revisions,
           (revision) => _.isEqual(attributes.strings, revision),
         )) {

--- a/src/services/syncer/strategies/transifex/utils/api.js
+++ b/src/services/syncer/strategies/transifex/utils/api.js
@@ -663,7 +663,7 @@ async function pushSourceContent(token, options) {
         );
         // Temporary fix for tikogames org to always update strings
         // until we implement the update_previous_source_strings flag
-        if (options.organization_slug === 'tikogames') {
+        if (options.organization_slug === 'tikogames' || meta.force_source_update === true) {
           mustPatchStrings = true;
         }
 

--- a/src/services/syncer/strategies/transifex/utils/api_payloads.js
+++ b/src/services/syncer/strategies/transifex/utils/api_payloads.js
@@ -45,10 +45,15 @@ function getDeleteStringPayload(stringId) {
 
 // If the string extracted from the codebase is unknown to Transifex (ie is
 // neither the latest upstream version nor any of the previous revisions), we
-// must update the string on Transifex
-function stringContentChanged(attributes, existingString, revisions) {
+// must update the string on Transifex.
+// When ignoreRevisions is true (e.g. force_source_update), we bypass the
+// revision guard and update whenever the content differs from the current
+// version, regardless of whether it matches a previous revision.
+function stringContentChanged(attributes, existingString, revisions, ignoreRevisions = false) {
+  const contentDiffers = !_.isEqual(attributes.strings, existingString.attributes.strings);
+  if (ignoreRevisions) return contentDiffers;
   return (
-    !_.isEqual(attributes.strings, existingString.attributes.strings)
+    contentDiffers
     && !_.some(
       revisions,
       (revision) => _.isEqual(attributes.strings, revision),


### PR DESCRIPTION
Implement functionality to accept `force_source_update` parameter, where the source strings are updated regardless of their state